### PR TITLE
Add pre function hook

### DIFF
--- a/share/urlwatch/examples/hooks.py.example
+++ b/share/urlwatch/examples/hooks.py.example
@@ -40,6 +40,28 @@ import re
 from urlwatch import ical2txt
 from urlwatch import html2txt
 
+# For doing logins in pre function
+import urllib, urllib2, cookielib
+
+# url and post_data are immutable but can be used for matching
+# changes to headers and cookiejar will be passed back to urlwatch
+def pre(url, post_data, headers, cookiejar):
+    # this url requires logging in
+    if url == 'http://example.org/stuff':
+        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookiejar))
+
+        login_data = urllib.urlencode({'username' : 'user',
+                                       'password' : 'pass'
+                                      })
+
+        request = urllib2.Request('http://example.org/login', login_data, headers)
+        response = opener.open(request)
+        # Check response.read(), if not OK:
+        # raise urllib2.HTTPError(url, 401, "Pre-login failed.", None, None)
+        # Raising an exception here will stop the real URL from being fetched.
+
+    return None
+
 
 def filter(url, data):
     if url == 'http://www.inso.tuwien.ac.at/lectures/usability/':

--- a/urlwatch
+++ b/urlwatch
@@ -246,6 +246,7 @@ if __name__ == '__main__':
     count = 0
 
     filter_func = lambda x, y: y
+    pre_func = lambda w, x, y, z: y
 
     if os.path.exists(hooks_py):
         log.info('using hooks.py from %s' % hooks_py)
@@ -254,7 +255,12 @@ if __name__ == '__main__':
             log.info('found and enabled filter function from hooks.py')
             filter_func = hooks.filter
         else:
-            log.warning('hooks.py has no filter function - ignoring')
+            log.warning('hooks.py has no filter function')
+        if hasattr(hooks, 'pre'):
+            log.info('found and enabled pre function from hooks.py')
+            pre_func = hooks.pre
+        else:
+            log.warning('hooks.py has no pre function')
     else:
         log.info('not using hooks.py (file not found)')
 
@@ -266,7 +272,7 @@ if __name__ == '__main__':
         if os.path.exists(filename):
             timestamp = os.stat(filename)[stat.ST_MTIME]
 
-        data = job.retrieve(timestamp, filter_func, headers, log)
+        data = job.retrieve(timestamp, filter_func, pre_func, headers, log)
         return filename, timestamp, data
 
     jobs = handler.parse_urls_txt(urls_txt)


### PR DESCRIPTION
The pre function in hooks.py can be used for sites that require
logging in before a URL can be fetched, by storing a session cookie
in the cookiejar.

It can also be used to change/add headers to the request.

The pre function isn't expected to return anything, but instead
it can directly change the passed headers or cookiejar references.

To stop the real URL from being fetched you can raise an HTTPError
exception. This will then be shown in urlwatch output if the
option --display-errors is enabled.

Simple example is included in hooks.py.example