### PR TITLE
Handle HTTP compression

### DIFF
--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -46,6 +46,7 @@ import os
 import stat
 import sys
 import re
+import zlib
 
 def get_current_user():
     try:
@@ -138,6 +139,13 @@ class UrlJob(JobBase):
         headers = response.info()
         content = response.read()
         encoding = 'utf-8'
+
+        # Handle HTTP compression
+        compression_type = headers.get('Content-Encoding')
+        if compression_type == 'gzip':
+            content = zlib.decompress(content, zlib.MAX_WBITS|32)
+        elif compression_type == 'deflate':
+            content = zlib.decompress(content, -zlib.MAX_WBITS)
 
         # Determine content type via HTTP headers
         content_type = headers.get('Content-type', '')


### PR DESCRIPTION
Hey thp, this is my first commit to GitHub. I noticed urlwatch wasn't working with some websites. It turns out they were sending (gzip) compressed data by default. This commit checks the Content-Encoding header for gzip (common) or deflate (less-common) and acts appropriately.
