### PR TITLE
Adding support for SMTP Authentication and TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ or download and install it manually from its project page at
 
     http://code.google.com/p/pythonfutures/
 
+If you need to use an authenticated SMTP connection, this package also relies
+on "keyring", it can be installed using:
+
+    pip install keyring
+
+or download and install manually from the project page at
+
+    https://bitbucket.org/kang/python-keyring-lib/
+
 
 QUICK START
 -----------
@@ -63,6 +72,15 @@ A: Please make sure to URL-encode the URLs properly. Use %20 for spaces.
 Q: The website I want to watch requires a POST request. How do I send one?
 A: Add the POST data in the same line, separated by a single space. The format
    in urls.txt is: http://example.org/script.cgi value=5&q=search&button=Go
+
+Q: The SMTP server I use requires TLS and authentication to port 587. How do I do that?
+A: Add your password to keyring using:
+
+    urlwatch -s smtp.example.com:587 -f alice@example.com --pass
+
+   Then run urlwatch with --tls and --auth supplied:
+
+    urlwatch -s smtp.example.com:587 -f alice@example.com -t bob@example.com --tls --auth ...
 
 
 CONTACT

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -1,15 +1,48 @@
-
 import smtplib
+try:
+    import keyring
+except ImportError:
+    keyring = None
+
 from email.mime.text import MIMEText
 
-def send(smtp_server, from_email, to_email, subject, body):
+
+def send(smtp_server, from_email, to_email, subject, body,
+         tls=False, auth=False):
     msg = MIMEText(body, 'plain', 'utf_8')
     msg['Subject'] = subject
     msg['From'] = from_email
     msg['To'] = to_email
 
+    if ':' in smtp_server:
+        smtp_hostname, smtp_port = smtp_server.split(':')
+        smtp_port = int(smtp_port)
+    else:
+        smtp_port = 25
+        smtp_hostname = smtp_server
+
     s = smtplib.SMTP()
-    s.connect(smtp_server, 25)
+    s.connect(smtp_hostname, smtp_port)
+    s.ehlo()
+    if tls:
+        s.starttls()
+    if auth and keyring is not None:
+        passwd = keyring.get_password(smtp_server, from_email)
+        if passwd is None:
+            raise ValueError(
+                'No password available in '
+                'keyring for {}, {}'.format(smtp_server, from_email))
+        s.login(from_email, passwd)
     s.sendmail(from_email, [to_email], msg.as_string())
     s.quit()
 
+
+def set_password(smtp_server, from_email):
+    ''' Set the keyring password for the mail connection. Interactive.'''
+    if keyring is None:
+        raise ImportError('keyring module missing - service unspported')
+    from getpass import getpass
+    keyring.set_password(smtp_server, from_email,
+                         getpass(prompt='Enter password '
+                                 'for {} using {}: '.format(
+                                     from_email, smtp_server)))

--- a/urlwatch
+++ b/urlwatch
@@ -163,7 +163,10 @@ if __name__ == '__main__':
     parser.add_option('-t', '--mailto', dest='email', metavar='ADDRESS', help='Send results via e-mail to ADDRESS')
     parser.add_option('-f', '--mailfrom', dest='email_from', metavar='ADDRESS', help='Alternate From: address for e-mail (--mailto)')
     parser.add_option('-s', '--smtp', dest='email_smtp', metavar='SERVER', help='SMTP server for e-mail (--mailto)')
-
+    parser.add_option('-p', '--pass', dest='password', action='store_true', help='Interactively set password for SMTP')
+    parser.add_option('-T', '--tls', dest='tls', action='store_true', help='Enable STARTTLS for SMTP')
+    parser.add_option('-A', '--auth',dest='auth',action='store_true', default=False, help='Enable authentication from keyring for SMTP')
+    
     parser.set_defaults(verbose=False, display_errors=False)
 
     (options, args) = parser.parse_args(sys.argv)
@@ -181,12 +184,18 @@ if __name__ == '__main__':
         log.info('turning display of errors ON')
         display_errors = True
 
+    if options.password:
+        mailer.set_password(options.email_smtp,options.email_from)
+        sys.exit(0)
+        
     if options.email:
         log.info('Send emails enabled')
         enable_emails = True
         email_smtp_server = options.email_smtp or 'localhost'
         email_sender_address = options.email_from or options.email
         email_receiver_address = options.email
+        email_tls = options.tls
+        email_auth = options.auth
     else:
         if options.email_from:
             log.error('--mailfrom without --mailto')
@@ -199,6 +208,7 @@ if __name__ == '__main__':
             sys.exit(1)
 
         enable_emails = False
+
 
     if options.urls:
         if os.path.isfile(options.urls):
@@ -383,7 +393,8 @@ if __name__ == '__main__':
                 subject = 'Changes detected (%d)' % len(summary)
                 mailer.send(email_smtp_server, email_sender_address,
                         email_receiver_address, subject,
-                        short_summary + '\n' + '\n'.join(details))
+                            short_summary + '\n' + '\n'.join(details),
+                            auth=email_auth,tls=email_tls)
                 log.info('E-Mail to %s sent.', email_receiver_address)
             except Exception, e:
                 log.warning('E-Mail delivery error: %s', e)


### PR DESCRIPTION
This should be a clean pull onto thp/urlwatch@master. Adds support for SMTP hosts in the form host:port and --tls and --auth (along with keyring password caching).
