### PR TITLE
Replace urllib usage with requests

### DIFF
--- a/urlwatch
+++ b/urlwatch
@@ -34,7 +34,7 @@ import os.path
 import os
 
 import shutil
-import urllib.error
+import requests
 import socket
 import argparse
 import logging
@@ -76,7 +76,7 @@ from urlwatch.handler import JobState, Report
 
 from urlwatch.storage import UrlsYaml, UrlsTxt, ConfigStorage, CacheDirStorage, CacheMiniDBStorage
 
-from urlwatch.jobs import JobBase
+from urlwatch.jobs import JobBase, NotModifiedError
 from urlwatch.filters import FilterBase
 from urlwatch.reporters import ReporterBase
 
@@ -319,14 +319,13 @@ def main(args):
         logger.debug('Job finished: %s', job_state.job)
 
         if job_state.exception is not None:
-            if isinstance(job_state.exception, urllib.error.HTTPError):
-                if job_state.exception.code == 304:
-                    logger.info('Job %s has not changed (HTTP 304)', job_state.job)
-                    report.unchanged(job_state)
-                else:
-                    # Instead of a full traceback, just show the HTTP error
-                    job_state.traceback = str(job_state.exception)
-                    report.error(job_state)
+            if isinstance(job_state.exception, NotModifiedError):
+                logger.info('Job %s has not changed (HTTP 304)', job_state.job)
+                report.unchanged(job_state)
+            elif isinstance(job_state.exception, requests.exceptions.RequestException):
+                # Instead of a full traceback, just show the HTTP error
+                job_state.traceback = str(job_state.exception)
+                report.error(job_state)
             else:
                 report.error(job_state)
         elif job_state.old_data is not None:


### PR DESCRIPTION
Hi @thp, let me know what you think of this as a patch for https://github.com/thp/urlwatch/issues/15
This is just a quick rewrite, I might have missed some corner cases. I decided to re-use `HTTPError` for 304 responses, since requests will not raise an exception for these.