### PR TITLE
Fix setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ m['scripts'] = [os.path.join(HERE, PACKAGE_NAME)]
 m['package_dir'] = {'': os.path.join(HERE, 'lib')}
 m['packages'] = ['.'.join(dirname[len(HERE)+1:].split(os.sep)[1:])
                  for dirname, _, files in os.walk(os.path.join(HERE, 'lib')) if '__init__.py' in files]
-m['data_files'] = [(dirname[len(HERE)+1:], [os.path.join(dirname[len(HERE)+1:], fn) for fn in files])
+m['data_files'] = [(dirname[len(HERE):], [os.path.join(dirname[len(HERE):], fn) for fn in files])
                    for dirname, _, files in os.walk(os.path.join(HERE, 'share')) if files]
 m['install_requires'] = DEPENDENCIES
 


### PR DESCRIPTION
Hi, I'm not sure exactly how this is supposed to work but the current setup.py prevents the package to install for me. `m['data_files']` looks like this:
```
[('hare/man/man1', ['hare/man/man1/urlwatch.1']), ('hare/urlwatch/examples', ['hare/urlwatch/examples/hooks.py.example', 'hare/urlwatch/examples/urls.yaml.example']), ('hare/urlwatch/examples/__pycache__', ['hare/urlwatch/examples/__pycache__/hooks.py.cpython-34.pyc', 'hare/urlwatch/examples/__pycache__/hooks.py.cpython-35.pyc'])]
```
And `setup.py install` fails with
```
error: can't copy 'hare/man/man1/urlwatch.1': doesn't exist or not a regular file
```