### PR TITLE
Ignore InsecureRequestWarning

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -43,7 +43,9 @@ import ssl
 import urlwatch
 
 from .util import TrackSubClasses
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
If `ssl_no_verify` is enabled for one URL, urllib3 will issue warnings:
```
/usr/lib64/python3.5/site-packages/urllib3/connectionpool.py:790: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
```
Since we control all the requests we make, I think we can globally silence this warning.