### PR TITLE
Fix JSON import

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -457,7 +457,7 @@ class MailGunReporter(TextReporter):
                   "html": body_html})
 
         try:
-            json_res = json.loads(result.content.decode("utf-8"))
+            json_res = result.json()
 
             if (result.status_code == 200):
                 logger.info("Mailgun response: id '{0}'. {1}".format(json_res['id'], json_res['message']))


### PR DESCRIPTION
Hello,

```json``` import is missing. We don't need it, due ```requests``` API.

Trackback:
```
Traceback (most recent call last):
  File "/Users/ervsts/Git/urlwatch/urlwatch", line 101, in <module>
    urlwatch_command.run()
  File "/Users/ervsts/Git/urlwatch/lib/urlwatch/command.py", line 167, in run
    self.urlwatcher.close()
  File "/Users/ervsts/Git/urlwatch/lib/urlwatch/main.py", line 96, in close
    self.report.finish()
  File "/Users/ervsts/Git/urlwatch/lib/urlwatch/handler.py", line 125, in finish
    ReporterBase.submit_all(self, self.job_states, duration)
  File "/Users/ervsts/Git/urlwatch/lib/urlwatch/reporters.py", line 95, in submit_all
    subclass(report, cfg, job_states, duration).submit()
  File "/Users/ervsts/Git/urlwatch/lib/urlwatch/reporters.py", line 460, in submit
    json_res = json.loads(result.content.decode("utf-8"))
NameError: name 'json' is not defined
```
Greetings,