### PR TITLE
Adding support of url that contains comma.

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -130,7 +130,7 @@ class UrlwatchCommand:
                     save = False
 
         if self.urlwatch_config.add is not None:
-            d = {k: v for k, v in (item.split('=', 1) for item in self.urlwatch_config.add.split(','))}
+            d = {k: v for k, v in (item.split('=', 1) for item in self.urlwatch_config.add.rsplit(',', 1))}
             job = JobBase.unserialize(d)
             print('Adding %r' % (job,))
             self.urlwatcher.jobs.append(job)


### PR DESCRIPTION
The command:
`urlwatch --add url=http://www.mysite.com,name=MySite`
does not work if mysite is:
[http://www.foo.com/page?&zips=1400,1410&orderby=date](http://www.foo.com/page?&zips=1400,1410&orderby=date)
because in the implementation you have supposed that there is no comma in the url.
The issue is raised by this line in command.py:
`d = {k: v for k, v in (item.split('=', 1) for item in self.urlwatch_config.add.split(','))}`
Supposing there is a higher probability to have a comma in the url than in the name, we could use instead:
`d = {k: v for k, v in (item.split('=', 1) for item in self.urlwatch_config.add.rsplit(',', 1))}`