### PR TITLE
Change HTTP header Content-Type for POST requests

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -203,6 +203,7 @@ class UrlJob(Job):
             self.method = "GET"
         if self.data is not None:
             self.method = "POST"
+            headers['Content-type'] = 'application/x-www-form-urlencoded'
             logger.info('Sending POST request to %s', self.url)
 
         if self.http_proxy is not None:


### PR DESCRIPTION
This is a solution for the general case when using the `data` option, as some sites will only allow POST requests to form results with this specification.

However, another approach would be creating a new `headers` option to allow other `Content-type` values (`application/json` for APIs, for example), but I don't know if that's the case.