### PR TITLE
Option to determine a minimum time interval for jobs

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -158,7 +158,7 @@ class ShellJob(Job):
     __kind__ = 'shell'
 
     __required__ = ('command',)
-    __optional__ = ()
+    __optional__ = ('interval')
 
     def get_location(self):
         return self.command
@@ -179,7 +179,7 @@ class UrlJob(Job):
     __kind__ = 'url'
 
     __required__ = ('url',)
-    __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy')
+    __optional__ = ('interval', 'cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy')
 
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 

--- a/lib/urlwatch/util.py
+++ b/lib/urlwatch/util.py
@@ -31,6 +31,8 @@
 import logging
 import os
 import platform
+import re
+from datetime import timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -87,3 +89,12 @@ def atomic_rename(old_filename, new_filename):
             os.remove(new_old_filename)
     else:
         os.rename(old_filename, new_filename)
+
+def get_timedelta(line):
+    timespaces = {"days": 0}
+    for timeunit in "year month week day hour minute second".split():
+        content = re.findall(r"([0-9]*?)\s*?" + timeunit, line)
+        if content:
+            timespaces[timeunit + "s"] = int(content[0])
+    timespaces["days"] += 30 * timespaces.pop("months", 0) + 365 * timespaces.pop("years", 0)
+    return timedelta(**timespaces).total_seconds()


### PR DESCRIPTION
This implements the `interval` option for jobs. It gets a human-readable string and will skip the job for this time since it was last processed.

    url: http://some-url.com
    interval: 3 hours

So it's possible to schedule urlwatcher for, let's say, every 5 minutes in the crontab, and it will fetch each URL at the configured frequency.