### PR TITLE
avoid exception if there is no ['smtp']['user'] field in config

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -343,11 +343,8 @@ class EMailReporter(TextReporter):
             logger.debug('Not sending e-mail (no changes)')
             return
         if self.config['method'] == "smtp":
-            if 'user' in self.config['smtp'] and self.config['smtp']['user']:
-                self.smtp_user = self.config['smtp']['user']
-            else:
-                self.smtp_user = self.config['from']
-            mailer = SMTPMailer(self.smtp_user, self.config['smtp']['host'], self.config['smtp']['port'],
+            smtp_user = self.config['smtp'].get('user', self.config['from'])
+            mailer = SMTPMailer(smtp_user, self.config['smtp']['host'], self.config['smtp']['port'],
                                 self.config['smtp']['starttls'], self.config['smtp']['keyring'])
         elif self.config['method'] == "sendmail":
             mailer = SendmailMailer(self.config['sendmail']['path'])

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -343,7 +343,7 @@ class EMailReporter(TextReporter):
             logger.debug('Not sending e-mail (no changes)')
             return
         if self.config['method'] == "smtp":
-            if self.config['smtp']['user']:
+            if 'user' in self.config['smtp'] and self.config['smtp']['user']:
                 self.smtp_user = self.config['smtp']['user']
             else:
                 self.smtp_user = self.config['from']


### PR DESCRIPTION
avoid exception
```
if self.config['smtp']['user']:
KeyError: 'user'
```
if there is no ['smtp']['user'] field in config, like it is the case for older existing configs. 