### PR TITLE
Correct XDG env variable for configuration

### DIFF
--- a/share/man/man1/urlwatch.1
+++ b/share/man/man1/urlwatch.1
@@ -71,13 +71,13 @@ list supported jobs/filters/reporters
 remove old cache entries
 .SH "FILES"
 .TP
-.B $XDG_CONFIG_DIR/urlwatch/urls.yaml
+.B $XDG_CONFIG_HOME/urlwatch/urls.yaml
 A list of URLs, commands and other jobs to watch
 .TP
-.B $XDG_CONFIG_DIR/urlwatch/hooks.py
+.B $XDG_CONFIG_HOME/urlwatch/hooks.py
 A Python module that can implement new job types, filters and reporters
 .TP
-.B $XDG_CONFIG_DIR/urlwatch/cache.db
+.B $XDG_CONFIG_HOME/urlwatch/cache.db
 A SQLite 3 database that contains the state history of jobs (for diffing)
 .SH AUTHOR
 Thomas Perl <thp.io/about>


### PR DESCRIPTION
appdirs.user_config_dir points to the location in XDG_CONFIG_HOME and
not XDG_CONFIG_DIR, incorrectly introduced with the addition of the
appdirs.user_config_dir change.