### PR TITLE
Loading urlwatch file with a non-relative path

### DIFF
--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -11,10 +11,10 @@ import tempfile
 import os
 import imp
 
-from lib.urlwatch import storage
-from lib.urlwatch.config import BaseConfig
-from lib.urlwatch.storage import JsonConfigStorage, YamlConfigStorage, UrlsJson, CacheMiniDBStorage
-from lib.urlwatch.main import Urlwatch
+from urlwatch import storage
+from urlwatch.config import BaseConfig
+from urlwatch.storage import JsonConfigStorage, YamlConfigStorage, UrlsJson, CacheMiniDBStorage
+from urlwatch.main import Urlwatch
 
 
 def test_required_classattrs_in_subclasses():


### PR DESCRIPTION
Hi,

I'm trying to package urlwatch-2.7 as a deb package and nose tests are always in error.
It seems to come from the "lib.urlwatch" import. This modification permits pybuild (debian build utility) to run successfully nose tests.

Is this change acceptable (I'm no python expert) ?

Maxime