### PR TITLE
Fix setuptools warn on build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ m['data_files'] = [
     ]),
 ]
 
+del m['copyright']
 setup(**m)


### PR DESCRIPTION
On setup.py build, setuptools warns for unkown distribution option named "copyright". 
```
$ python3 setup.py build
/usr/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'copyright'
  warnings.warn(msg)
running build
running build_py
running build_scripts
```

This patch removes option "copyright" before giving options to setuptools.