### PR TITLE
Adds fallback on editor when $VISUAL and $EDITOR are absent

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -55,6 +55,8 @@ class UrlwatchCommand:
         if editor is None:
             editor = os.environ.get('VISUAL', None)
         if editor is None:
+            editor = shutil.which('editor', os.X_OK)
+        if editor is None:
             print('Please set $VISUAL or $EDITOR.')
             return 1
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -169,6 +169,8 @@ class BaseTextualFileStorage(BaseFileStorage, metaclass=ABCMeta):
         if editor is None:
             editor = os.environ.get('VISUAL', None)
         if editor is None:
+            editor = shutil.which('editor', os.X_OK)
+        if editor is None:
             print('Please set $VISUAL or $EDITOR.')
             return 1
 


### PR DESCRIPTION
urlwatch allow to edit config files with an urlwatch command. This command call an
editor for this purpose. Editor is chosen by reading $VISUAL and $EDITOR. If both are
absent then urlwatch now attemps to call editor