### PR TITLE
Moving cache file to XDG_CACHE_DIR instead or XGD_CONFIG_DIR

### DIFF
--- a/share/man/man1/urlwatch.1
+++ b/share/man/man1/urlwatch.1
@@ -77,7 +77,7 @@ A list of URLs, commands and other jobs to watch
 .B $XDG_CONFIG_HOME/urlwatch/hooks.py
 A Python module that can implement new job types, filters and reporters
 .TP
-.B $XDG_CONFIG_HOME/urlwatch/cache.db
+.B $XDG_CACHE_HOME/urlwatch/cache.db
 A SQLite 3 database that contains the state history of jobs (for diffing)
 .SH AUTHOR
 Thomas Perl <thp.io/about>

--- a/urlwatch
+++ b/urlwatch
@@ -40,6 +40,7 @@ from appdirs import AppDirs
 
 pkgname = 'urlwatch'
 urlwatch_dir = os.path.expanduser(os.path.join('~', '.' + pkgname))
+urlwatch_cache_dir = AppDirs(pkgname).user_cache_dir
 
 if not os.path.exists(urlwatch_dir):
     urlwatch_dir = AppDirs(pkgname).user_config_dir
@@ -86,8 +87,12 @@ def setup_logger(verbose):
 if __name__ == '__main__':
     config_file = os.path.join(urlwatch_dir, CONFIG_FILE)
     urls_file = os.path.join(urlwatch_dir, URLS_FILE)
-    cache_file = os.path.join(urlwatch_dir, CACHE_FILE)
     hooks_file = os.path.join(urlwatch_dir, HOOKS_FILE)
+    new_cache_file = os.path.join(urlwatch_cache_dir, CACHE_FILE)
+    old_cache_file = os.path.join(urlwatch_dir, CACHE_FILE)
+    cache_file = new_cache_file
+    if os.path.exists(old_cache_file) and not os.path.exists(new_cache_file):
+        cache_file = old_cache_file
 
     command_config = CommandConfig(pkgname, urlwatch_dir, bindir, prefix,
                                    config_file, urls_file, hooks_file, cache_file, False)


### PR DESCRIPTION
Here is a pull request to change default cache directory from XGD_CONFIG_DIR to XDG_CACHE_DIR.

Three cases are handled:
1.) If the file exists in XDG_CONFIG_HOME, use that one
2.) If the file doesn’t exist, create a new one in XDG_CACHE_HOME
3.) If both files exist, either fail or use the XDG_CACHE_HOME file (presumably newer)

Man page has been updated