### PR TITLE
Support for custom HTTP request headers

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -260,7 +260,7 @@ class UrlJob(Job):
     def add_custom_headers(self, headers):
         """
         Adds custom request headers from the job list (URLs) to the pre-filled dictionary `headers`.
-        Conflicting headers are overwritten case-insensitively.
+        Pre-filled values of conflicting header keys (case-insensitive) are overwritten by custom value.
         """
         headers_to_remove = [x for x in headers if x.lower() in [y.lower() for y in self.headers]]
         for header in headers_to_remove:

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -179,7 +179,8 @@ class UrlJob(Job):
     __kind__ = 'url'
 
     __required__ = ('url',)
-    __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy')
+    __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
+                    'headers')
 
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 
@@ -221,6 +222,9 @@ class UrlJob(Job):
             logger.info('Using local filesystem (%s URI scheme)', file_scheme)
             return open(self.url[len(file_scheme):], 'rt').read()
 
+        if self.headers:
+            self.add_custom_headers(headers)
+
         response = requests.request(url=self.url,
                                     data=self.data,
                                     headers=headers,
@@ -252,6 +256,16 @@ class UrlJob(Job):
                 return response.content.decode('ascii', 'ignore')
 
         return response.text
+
+    def add_custom_headers(self, headers):
+        """
+        Adds custom request headers from the job list (URLs) to the pre-filled dictionary `headers`.
+        Conflicting headers are overwritten case-insensitively.
+        """
+        headers_to_remove = [x for x in headers if x.lower() in [y.lower() for y in self.headers]]
+        for header in headers_to_remove:
+            headers.pop(header, None)
+        headers.update(self.headers)
 
 
 class BrowserJob(Job):


### PR DESCRIPTION
These changes would implement #175 and #192. 

I needed urlwatch support for a JSON API endpoint. The default POST content-type by urlwatch was a blocker. For that reason I made this implementation. Of course this could be utilized in many ways.

My monitoring job for the JSON API:
```json
name: JSON API
url: <URL>
data: <RAW JSON PAYLOAD>
headers:
  Content-Type: application/json;charset=UTF-8
  User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64) Vivaldi/1.96.1147.36
```