### PR TITLE
.gitignore: Ignore common files in a Python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,67 @@
-__pycache__
+# IDEs
 .idea
-build
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Ignore tags created by etags, ctags, gtags (GNU global) and cscope
+TAGS
+.TAGS
+!TAGS/
+tags
+.tags
+!tags/
+gtags.files
+GTAGS
+GRTAGS
+GPATH
+GSYMS
+cscope.files
+cscope.out
+cscope.in.out
+cscope.po.out


### PR DESCRIPTION
This adds some common files in a Python project to the .gitignore file.
These were mostly taken from GitHub's own `gitignore` repository [1]
[2] and make sure that metadata created during running and testing is
not interfering with the actual content.

[1]: https://github.com/github/gitignore/blob/master/Python.gitignore
[2]: https://github.com/github/gitignore/blob/master/Global/Tags.gitignore