### PR TITLE
Raise exception in case of empty job output

### DIFF
--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -34,7 +34,7 @@ import time
 import traceback
 
 from .filters import FilterBase
-from .jobs import NotModifiedError
+from .jobs import NotModifiedError, EmptyJobOutputError
 from .reporters import ReporterBase
 
 logger = logging.getLogger(__name__)
@@ -89,6 +89,8 @@ class JobState(object):
                         else:
                             subfilter = None
                         data = FilterBase.process(filter_kind, subfilter, self, data)
+            if not data:
+                raise EmptyJobOutputError('No usable content retrieved')
             self.new_data = data
             self.tries = 0
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -61,6 +61,11 @@ class NotModifiedError(Exception):
     ...
 
 
+class EmptyJobOutputError(Exception):
+    """Exception raised when job output was empty"""
+    ...
+
+
 class JobBase(object, metaclass=TrackSubClasses):
     __subclasses__ = {}
 


### PR DESCRIPTION
This addresses #245 and makes sure an exception is raised (resulting in
an error) when the output from a job is empty, since this is a good
indication that something is misconfigured.