### PR TITLE
Implement ETag support

### DIFF
--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -51,6 +51,7 @@ class JobState(object):
         self.exception = None
         self.traceback = None
         self.tries = 0
+        self.etag = None
 
     def load(self):
         self.old_data, self.timestamp, self.tries, self.etag = self.cache_storage.load(self.job, self.job.get_guid())
@@ -62,7 +63,7 @@ class JobState(object):
             # If no new data has been retrieved due to an exception, use the old job data
             self.new_data = self.old_data
 
-        self.cache_storage.save(self.job, self.job.get_guid(), self.new_data, time.time(), self.tries)
+        self.cache_storage.save(self.job, self.job.get_guid(), self.new_data, time.time(), self.tries, self.etag)
 
     def process(self):
         logger.info('Processing: %s', self.job)

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -53,7 +53,7 @@ class JobState(object):
         self.tries = 0
 
     def load(self):
-        self.old_data, self.timestamp, self.tries = self.cache_storage.load(self.job, self.job.get_guid())
+        self.old_data, self.timestamp, self.tries, self.etag = self.cache_storage.load(self.job, self.job.get_guid())
         if self.tries is None:
             self.tries = 0
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -197,6 +197,9 @@ class UrlJob(Job):
             'https': os.getenv('HTTPS_PROXY'),
         }
 
+        if job_state.etag is not None:
+            headers['If-None-Match'] = job_state.etag
+
         if job_state.timestamp is not None:
             headers['If-Modified-Since'] = email.utils.formatdate(job_state.timestamp)
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -204,6 +204,7 @@ class UrlJob(Job):
             headers['If-Modified-Since'] = email.utils.formatdate(job_state.timestamp)
 
         if self.ignore_cached:
+            headers['If-None-Match'] = None
             headers['If-Modified-Since'] = email.utils.formatdate(0)
             headers['Cache-Control'] = 'max-age=172800'
             headers['Expires'] = email.utils.formatdate()

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -237,6 +237,9 @@ class UrlJob(Job):
         if response.status_code == 304:
             raise NotModifiedError()
 
+        # Save ETag from response into job_state, which will be saved in cache
+        job_state.etag = response.headers.get('ETag')
+
         # If we can't find the encoding in the headers, requests gets all
         # old-RFC-y and assumes ISO-8859-1 instead of UTF-8. Use the old
         # urlwatch behavior and try UTF-8 decoding first.

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -359,7 +359,7 @@ class CacheStorage(BaseFileStorage, metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def save(self, job, guid, data, timestamp, tries):
+    def save(self, job, guid, data, timestamp, tries, etag=None):
         ...
 
     @abstractmethod
@@ -372,12 +372,12 @@ class CacheStorage(BaseFileStorage, metaclass=ABCMeta):
 
     def backup(self):
         for guid in self.get_guids():
-            data, timestamp, tries = self.load(None, guid)
-            yield guid, data, timestamp, tries
+            data, timestamp, tries, etag = self.load(None, guid)
+            yield guid, data, timestamp, tries, etag
 
     def restore(self, entries):
-        for guid, data, timestamp, tries in entries:
-            self.save(None, guid, data, timestamp, tries)
+        for guid, data, timestamp, tries, etag in entries:
+            self.save(None, guid, data, timestamp, tries, etag)
 
     def gc(self, known_guids):
         for guid in set(self.get_guids()) - set(known_guids):
@@ -420,10 +420,10 @@ class CacheDirStorage(CacheStorage):
 
         timestamp = os.stat(filename)[stat.ST_MTIME]
 
-        return data, timestamp
+        return data, timestamp, None
 
-    def save(self, job, guid, data, timestamp):
-        # Timestamp is always ignored
+    def save(self, job, guid, data, timestamp, etag=None):
+        # Timestamp and ETag are always ignored
         filename = self._get_filename(guid)
         with open(filename, 'w+') as fp:
             fp.write(data)
@@ -443,6 +443,7 @@ class CacheEntry(minidb.Model):
     timestamp = int
     data = str
     tries = int
+    etag = str
 
 
 class CacheMiniDBStorage(CacheStorage):
@@ -464,15 +465,15 @@ class CacheMiniDBStorage(CacheStorage):
         return (guid for guid, in CacheEntry.query(self.db, minidb.Function('distinct', CacheEntry.c.guid)))
 
     def load(self, job, guid):
-        for data, timestamp, tries in CacheEntry.query(self.db, CacheEntry.c.data // CacheEntry.c.timestamp // CacheEntry.c.tries,
+        for data, timestamp, tries, etag in CacheEntry.query(self.db, CacheEntry.c.data // CacheEntry.c.timestamp // CacheEntry.c.tries // CacheEntry.c.etag,
                                                        order_by=minidb.columns(CacheEntry.c.timestamp.desc, CacheEntry.c.tries.desc),
                                                        where=CacheEntry.c.guid == guid, limit=1):
-            return data, timestamp, tries
+            return data, timestamp, tries, etag
 
-        return None, None, 0
+        return None, None, 0, None
 
-    def save(self, job, guid, data, timestamp, tries):
-        self.db.save(CacheEntry(guid=guid, timestamp=timestamp, data=data, tries=tries))
+    def save(self, job, guid, data, timestamp, tries, etag=None):
+        self.db.save(CacheEntry(guid=guid, timestamp=timestamp, data=data, tries=tries, etag=etag))
         self.db.commit()
 
     def delete(self, guid):

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -466,8 +466,8 @@ class CacheMiniDBStorage(CacheStorage):
 
     def load(self, job, guid):
         for data, timestamp, tries, etag in CacheEntry.query(self.db, CacheEntry.c.data // CacheEntry.c.timestamp // CacheEntry.c.tries // CacheEntry.c.etag,
-                                                       order_by=minidb.columns(CacheEntry.c.timestamp.desc, CacheEntry.c.tries.desc),
-                                                       where=CacheEntry.c.guid == guid, limit=1):
+                                                             order_by=minidb.columns(CacheEntry.c.timestamp.desc, CacheEntry.c.tries.desc),
+                                                             where=CacheEntry.c.guid == guid, limit=1):
             return data, timestamp, tries, etag
 
         return None, None, 0, None

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -161,14 +161,14 @@ def prepare_retry_test():
 def test_number_of_tries_in_cache_is_increased():
     urlwatcher, cache_storage = prepare_retry_test()
     job = urlwatcher.jobs[0]
-    old_data, timestamp, tries = cache_storage.load(job, job.get_guid())
+    old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
     assert tries == 0
 
     urlwatcher.run_jobs()
     urlwatcher.run_jobs()
 
     job = urlwatcher.jobs[0]
-    old_data, timestamp, tries = cache_storage.load(job, job.get_guid())
+    old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
 
     assert tries == 2
     assert urlwatcher.report.job_states[-1].verb == 'error'
@@ -179,7 +179,7 @@ def test_report_error_when_out_of_tries():
     urlwatcher, cache_storage = prepare_retry_test()
 
     job = urlwatcher.jobs[0]
-    old_data, timestamp, tries = cache_storage.load(job, job.get_guid())
+    old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
     assert tries == 0
 
     urlwatcher.run_jobs()
@@ -194,13 +194,13 @@ def test_reset_tries_to_zero_when_successful():
     urlwatcher, cache_storage = prepare_retry_test()
 
     job = urlwatcher.jobs[0]
-    old_data, timestamp, tries = cache_storage.load(job, job.get_guid())
+    old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
     assert tries == 0
 
     urlwatcher.run_jobs()
 
     job = urlwatcher.jobs[0]
-    old_data, timestamp, tries = cache_storage.load(job, job.get_guid())
+    old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
     assert tries == 1
 
     # use an url that definitely exists
@@ -210,5 +210,5 @@ def test_reset_tries_to_zero_when_successful():
     urlwatcher.run_jobs()
 
     job = urlwatcher.jobs[0]
-    old_data, timestamp, tries = cache_storage.load(job, job.get_guid())
+    old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
     assert tries == 0


### PR DESCRIPTION
This series implements ETag support for `UrlJob` as discussed in #248. It adds an additional column to the caching database, saves the ETag returned from the server after an initial request, and appends this ETag to any further requests. The server will then return a 304 (`Not Modified`) status code, if nothing has changed, which the existing code already handles fine (due to the support for `If-Modified-Since`).