### PR TITLE
Raise exception in case of empty job output

### DIFF
--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -34,7 +34,7 @@ import time
 import traceback
 
 from .filters import FilterBase
-from .jobs import NotModifiedError
+from .jobs import NotModifiedError, EmptyJobOutputError
 from .reporters import ReporterBase
 
 logger = logging.getLogger(__name__)
@@ -89,6 +89,9 @@ class JobState(object):
                         else:
                             subfilter = None
                         data = FilterBase.process(filter_kind, subfilter, self, data)
+
+            if not data and not self.job.ignore_empty:
+                raise EmptyJobOutputError()
             self.new_data = data
             self.tries = 0
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -61,11 +61,18 @@ class NotModifiedError(Exception):
     ...
 
 
+class EmptyJobOutputError(Exception):
+    """Exception raised when job output was empty"""
+    ...
+
+
 class JobBase(object, metaclass=TrackSubClasses):
     __subclasses__ = {}
 
     __required__ = ()
     __optional__ = ()
+
+    ignore_empty = False
 
     def __init__(self, **kwargs):
         # Set optional keys to None
@@ -129,7 +136,7 @@ class JobBase(object, metaclass=TrackSubClasses):
 
     @classmethod
     def from_dict(cls, data):
-        return cls(**{k: v for k, v in list(data.items()) if k in cls.__required__ or k in cls.__optional__})
+        return cls(**{k: v for k, v in list(data.items()) if k in cls.__required__ or k in cls.__optional__ or k in ['ignore_empty']})
 
     def __repr__(self):
         return '<%s %s>' % (self.__kind__, ' '.join('%s=%r' % (k, v) for k, v in list(self.to_dict().items())))

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -131,7 +131,7 @@ class JobBase(object, metaclass=TrackSubClasses):
         return cls.__subclasses__[kind].from_dict(data)
 
     def to_dict(self):
-        return {k: getattr(self, k) for keys in (self.__required__, self.__optional__) for k in keys
+        return {k: getattr(self, k) for keys in (self.__required__, self.__optional__, ('ignore_empty',)) for k in keys
                 if getattr(self, k) is not None}
 
     @classmethod

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -34,7 +34,7 @@ import logging
 import requests
 
 from .handler import JobState
-from .jobs import NotModifiedError
+from .jobs import NotModifiedError, EmptyJobOutputError
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +70,9 @@ def run_jobs(urlwatcher):
             if isinstance(job_state.exception, NotModifiedError):
                 logger.info('Job %s has not changed (HTTP 304)', job_state.job)
                 report.unchanged(job_state)
+            elif isinstance(job_state.exception, EmptyJobOutputError):
+                logger.info('Job %s has produced no output', job_state.job)
+                report.error(job_state)
             elif job_state.tries < max_tries:
                 logger.debug('This was try %i of %i for job %s', job_state.tries,
                              max_tries, job_state.job)


### PR DESCRIPTION
This addresses #245 and makes sure an exception is raised (resulting in
an error) when the output from a job is empty, since this is a pretty
good indication for a misconfiguration. The `ignore_empty` disables this
check, making it still possible to monitor empty pages, e.g. in case you
want to watch for an empty page getting filled with content.