### PR TITLE
Use variable names from requests library instead of HTTP status codes

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -234,7 +234,7 @@ class UrlJob(Job):
                                     proxies=proxies)
 
         response.raise_for_status()
-        if response.status_code == 304:
+        if response.status_code == requests.codes.not_modified:
             raise NotModifiedError()
 
         # If we can't find the encoding in the headers, requests gets all

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -485,7 +485,7 @@ class MailGunReporter(TextReporter):
         try:
             json_res = result.json()
 
-            if (result.status_code == 200):
+            if (result.status_code == requests.codes.ok):
                 logger.info("Mailgun response: id '{0}'. {1}".format(json_res['id'], json_res['message']))
             else:
                 logger.error("Mailgun error: {0}".format(json_res['message']))
@@ -529,7 +529,7 @@ class TelegramReporter(TextReporter):
         try:
             json_res = result.json()
 
-            if (result.status_code == 200):
+            if (result.status_code == requests.codes.ok):
                 logger.info("Telegram response: ok '{0}'. {1}".format(json_res['ok'], json_res['result']))
             else:
                 logger.error("Telegram error: {0}".format(json_res['description']))


### PR DESCRIPTION
This replaces the hardcoded status codes in the existing code by the
variable names from the requests library, since it is considered bad
practice to use hardcoded constants directly in the code.