### PR TITLE
Add optional option to ignore network errors in UrlJob

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -180,7 +180,7 @@ class UrlJob(Job):
 
     __required__ = ('url',)
     __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
-                    'headers')
+                    'headers', 'ignore_network')
 
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -70,6 +70,8 @@ def run_jobs(urlwatcher):
             if isinstance(job_state.exception, NotModifiedError):
                 logger.info('Job %s has not changed (HTTP 304)', job_state.job)
                 report.unchanged(job_state)
+            elif isinstance(job_state.exception, requests.exceptions.ConnectionError) and job_state.job.ignore_network:
+                logger.info('Connection error while executing job %s', job_state.job)
             elif job_state.tries < max_tries:
                 logger.debug('This was try %i of %i for job %s', job_state.tries,
                              max_tries, job_state.job)


### PR DESCRIPTION
This implements a per-entry configuration option named `ignore_network`
that can be specified if (temporary) network errors should be ignored.
When this option is specified, you won't be notified in case of a
network error. The default is still the same, i.e. if this key is not
present, you'll still get an error and will be notified. This was
discussed and tested in #218.