### PR TITLE
Avoid a crash when a Telegram user has only one name (first_name) set.

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -194,7 +194,7 @@ class UrlwatchCommand:
             for chat_info in requests.get('https://api.telegram.org/bot{}/getUpdates'.format(bot_token)).json()['result']:
                 chat = chat_info['message']['chat']
                 if chat['type'] == 'private':
-                    chats[str(chat['id'])] = ' '.join((chat['first_name'], chat['last_name']))
+                    chats[str(chat['id'])] = ' '.join((chat['first_name'], chat['last_name'])) if 'last_name' in chat else chat['first_name']
 
             if not chats:
                 print('No chats found. Say hello to your bot at https://t.me/{}'.format(info['result']['username']))


### PR DESCRIPTION
The "last_name" property of a telegram chat might not be set, if not specified by the Telegram user. This leads to a KeyError, which was not caught.