### PR TITLE
Allow multiple chats for telegram reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,19 @@ Eventually it will tell you the bot token (in the form seen above,
 You can then click on the link of your bot, which will send the message `/start`.
 At this point, you can use the command `urlwatch --telegram-chats` to list the
 private chats the bot is involved with. This is the chat ID that you need to put
-into the config file as `chat_id`, and don't forget to also enable the reporter.
+into the config file as `chat_id`. You may add multiple chat IDs as a YAML list:
+```yaml
+telegram:
+  bot_token: '999999999:3tOhy2CuZE0pTaCtszRfKpnagOG8IQbP5gf' # your bot api token
+  chat_id:
+    - '11111111'
+    - '22222222'
+  enabled: true
+```
+
+Don't forget to also enable the reporter.
+
+
 
 BROWSER
 -------

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -506,7 +506,8 @@ class TelegramReporter(TextReporter):
     def submit(self):
 
         bot_token = self.config['bot_token']
-        chat_id = self.config['chat_id']
+        chat_ids = self.config['chat_id']
+        chat_ids = [chat_ids] if isinstance(chat_ids, str) else chat_ids
 
         text = '\n'.join(super().submit())
 
@@ -515,9 +516,11 @@ class TelegramReporter(TextReporter):
             return
 
         result = None
-
         for chunk in self.chunkstring(text, self.MAX_LENGTH):
-            result = self.submitToTelegram(bot_token, chat_id, chunk)
+            for chat_id in chat_ids:
+                res = self.submitToTelegram(bot_token, chat_id, chunk)
+                if res.status_code != requests.codes.ok or res is None:
+                    result = res
 
         return result
 


### PR DESCRIPTION
Configure using a yaml list:
---
report:
  telegram:
    bot_token: '<token>'
    chat_id:
      - '<chat1>'
      - '<chat2>'
    enabled: true