### PR TITLE
Fixed incorrect name for chat_id config in the default config

### DIFF
--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -100,7 +100,7 @@ DEFAULT_CONFIG = {
         'telegram': {
             'enabled': False,
             'bot_token': '',
-            'chat-id': '',
+            'chat_id': '',
         },
         'mailgun': {
             'enabled': False,


### PR DESCRIPTION
When adding a telegram configuration using the variable names from the default config the following error is thrown:
```KeyError: 'chat_id'```
Changing the name from chat-id to chat_id fixes this problem.