### PR TITLE
disambiguate possible nested set in regex

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 
 # Regular expressions that match the added/removed markers of GNU wdiff output
 WDIFF_ADDED_RE = r'[{][+].*?[+][}]'
-WDIFF_REMOVED_RE = r'[[][-].*?[-][]]'
+WDIFF_REMOVED_RE = r'[\[][-].*?[-][]]'
 
 
 class ReporterBase(object, metaclass=TrackSubClasses):


### PR DESCRIPTION
Eliminate Python 3.7's FutureWarning for possible nested sets.

See https://docs.python.org/3/whatsnew/3.7.html#re