### PR TITLE
Use hyperlink in HtmlReporter for browser jobs

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -148,6 +148,9 @@ class Job(JobBase):
     __required__ = ()
     __optional__ = ('name', 'filter', 'max_tries', 'diff_tool')
 
+    # determine if hyperlink "a" tag is used in HtmlReporter
+    LOCATION_IS_URL = False
+
     def pretty_name(self):
         return self.name if self.name else self.get_location()
 
@@ -182,7 +185,7 @@ class UrlJob(Job):
     __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
                     'headers', 'ignore_connection_errors')
 
-    location_is_url = True
+    LOCATION_IS_URL = True
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 
     def get_location(self):
@@ -283,7 +286,7 @@ class BrowserJob(Job):
 
     __required__ = ('navigate',)
 
-    location_is_url = True
+    LOCATION_IS_URL = True
 
     def get_location(self):
         return self.navigate

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -182,6 +182,7 @@ class UrlJob(Job):
     __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
                     'headers', 'ignore_connection_errors')
 
+    location_is_url = True
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 
     def get_location(self):
@@ -281,6 +282,8 @@ class BrowserJob(Job):
     __kind__ = 'browser'
 
     __required__ = ('navigate',)
+
+    location_is_url = True
 
     def get_location(self):
         return self.navigate

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -169,7 +169,7 @@ class HtmlReporter(ReporterBase):
         for job_state in self.report.get_filtered_job_states(self.job_states):
             job = job_state.job
 
-            if job.__kind__ == 'url':
+            if getattr(job, 'location_is_url', False):
                 title = '<a href="{location}">{pretty_name}</a>'
             elif job.pretty_name() != job.get_location():
                 title = '<span title="{location}">{pretty_name}</span>'

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -169,7 +169,7 @@ class HtmlReporter(ReporterBase):
         for job_state in self.report.get_filtered_job_states(self.job_states):
             job = job_state.job
 
-            if getattr(job, 'location_is_url', False):
+            if job.LOCATION_IS_URL:
                 title = '<a href="{location}">{pretty_name}</a>'
             elif job.pretty_name() != job.get_location():
                 title = '<span title="{location}">{pretty_name}</span>'


### PR DESCRIPTION
Add `location_is_url` to `BrowserJob` and `UrlJob`.
Use this attribute to determine whether to use hyperlink 'a' tag in HtmlReporter.
Custom job classes can also utilize this attribute.