### PR TITLE
render browser jobs' web pages asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ urlwatch 2 requires:
   * [keyring](https://github.com/jaraco/keyring/)
   * [appdirs](https://github.com/ActiveState/appdirs)
   * [lxml](https://lxml.de)
+  * [asyncio](https://pypi.org/project/asyncio/) (Python 3.3 only)
 
 The dependencies can be installed with (add `--user` to install to `$HOME`):
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Optional dependencies (install via `python3 -m pip install <packagename>`):
 
   * Pushover reporter: [chump](https://github.com/karanlyons/chump/)
   * Pushbullet reporter: [pushbullet.py](https://github.com/randomchars/pushbullet.py)
-  * "browser" job kind: [requests-html](https://html.python-requests.org)
+  * "browser" job kind: [pyppeteer](https://github.com/miyakogi/pyppeteer), Python 3.6 or newer
   * Unit testing: [pycodestyle](http://pycodestyle.pycqa.org/en/latest/)
 
 
@@ -217,7 +217,7 @@ BROWSER
 -------
 
 If the webpage you are trying to watch runs client-side JavaScript to
-render the page, [Requests-HTML](http://html.python-requests.org) can
+render the page, [Pyppeteer](https://github.com/miyakogi/pyppeteer) can
 now be used to render the page in a headless Chromium instance first
 and then use the HTML of the resulting page.
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ m['name'] = 'urlwatch'
 m['author'], m['author_email'] = re.match(r'(.*) <(.*)>', m['author']).groups()
 m['description'], m['long_description'] = docs[0].strip().split('\n\n', 1)
 m['install_requires'] = ['minidb', 'PyYAML', 'requests', 'keyring', 'pycodestyle', 'appdirs', 'lxml']
+if sys.version_info < (3, 4):
+    m['install_requires'].extend(['asyncio'])
 m['scripts'] = ['urlwatch']
 m['package_dir'] = {'': 'lib'}
 m['packages'] = ['urlwatch']


### PR DESCRIPTION
An alternative of #298. Opening a new pull request due to very significant differences.

Re-implement `BrowserJob` as a subclass of a new class `AsyncJob`, and directly use `pyppeteer` without using `requests_html`.

`worker.py` is still changed, but to a lesser extent, with only additions but no restructuring.

Design of `AsyncJob` workflow:
* Before `run_parallel`: All async jobs are given the same main event loop. The event loop is then put onto an independent thread and starts running.
* During `run_parallel`: No code change in `worker.py` in this stage. In each worker thread, the `retrieve` method of any async job schedules tasks onto the main event loop, and wait for the result and return it.
* After `run_parallel`: The event loop is stopped, and async jobs have a chance to do final clean up.

This is the best method I came up with that can utilize the efficiency of `pyppeteer`'s async API without making urlwatch's code full blown async.
It's also my first time using asyncio / coroutines. Suggestions/criticism more than welcome.