### PR TITLE
Add enum34 dependency for Python 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ urlwatch 2 requires:
   * [keyring](https://github.com/jaraco/keyring/)
   * [appdirs](https://github.com/ActiveState/appdirs)
   * [lxml](https://lxml.de)
+  * [enum34](https://pypi.org/project/enum34/) (Python 3.3 only)
 
 The dependencies can be installed with (add `--user` to install to `$HOME`):
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ m['name'] = 'urlwatch'
 m['author'], m['author_email'] = re.match(r'(.*) <(.*)>', m['author']).groups()
 m['description'], m['long_description'] = docs[0].strip().split('\n\n', 1)
 m['install_requires'] = ['minidb', 'PyYAML', 'requests', 'keyring', 'pycodestyle', 'appdirs', 'lxml']
+if sys.version_info < (3, 4):
+    m['install_requires'].extend(['enum34'])
 m['scripts'] = ['urlwatch']
 m['package_dir'] = {'': 'lib'}
 m['packages'] = ['urlwatch']


### PR DESCRIPTION
`enum` is only in the standard library since Python 3.4