### PR TITLE
Set `job_state.tries` to zero before saving new jobs

### DIFF
--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -101,4 +101,5 @@ def run_jobs(urlwatcher):
                     job_state.save()
         else:
             report.new(job_state)
+            job_state.tries = 0
             job_state.save()


### PR DESCRIPTION
Fix regression introduced by #291.

If a new job's first few runs had errors, only the first successful run will be reported as "new", but also a non-zero `tries` that should be reset.