### PR TITLE
Make `UrlsYaml.parse` actually parse

### DIFF
--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -315,7 +315,7 @@ class UrlsYaml(BaseYamlFileStorage, UrlsBaseFileStorage):
         filename = args[0]
         if filename is not None and os.path.exists(filename):
             with open(filename) as fp:
-                return yaml.load_all(fp)
+                return [JobBase.unserialize(job) for job in yaml.load_all(fp) if job is not None]
 
     def save(self, *args):
         jobs = args[0]


### PR DESCRIPTION
`yaml.load_all` does lazy evaluation, and only returns a generator.
Modify `UrlsYaml.parse` to be similar to `UrlsYaml.load` to force non-lazy parsing.
Close #316