### PR TITLE
Add `ignore_http_error_codes` attribute to url job

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ url: https://example.com/
 ignore_connection_errors: true
 ```
 
+Similarly, you might want to ignore some (temporary) HTTP errors on the
+server side:
+
+```yaml
+url: https://example.com/
+ignore_http_error_codes: 503
+```
+
+or ignore all HTTP errors if you like:
+
+```yaml
+url: https://example.com/
+ignore_http_error_codes: 4xx, 5xx
+```
+
 For web pages with misconfigured HTTP headers or rare encodings, it may
 be useful to explicitly specify an encoding from Python's
 [Standard Encodings](https://docs.python.org/3/library/codecs.html#standard-encodings).

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ server side:
 
 ```yaml
 url: https://example.com/
-ignore_http_error_codes: 503
+ignore_http_error_codes: 408, 429, 500, 502, 503, 504
 ```
 
 or ignore all HTTP errors if you like:

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -143,6 +143,12 @@ class JobBase(object, metaclass=TrackSubClasses):
     def retrieve(self, job_state):
         raise NotImplementedError()
 
+    def format_error(self, exception, tb):
+        return tb
+
+    def ignore_error(self, exception):
+        return False
+
 
 class Job(JobBase):
     __required__ = ()
@@ -279,6 +285,15 @@ class UrlJob(Job):
         for header in headers_to_remove:
             headers.pop(header, None)
         headers.update(self.headers)
+
+    def format_error(self, exception, tb):
+        if isinstance(exception, requests.exceptions.RequestException):
+            # Instead of a full traceback, just show the HTTP error
+            return str(exception)
+        return tb
+
+    def ignore_error(self, exception):
+        return isinstance(exception, requests.exceptions.ConnectionError) and self.ignore_connection_errors
 
 
 class BrowserJob(Job):

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -297,12 +297,14 @@ class UrlJob(Job):
             return True
         elif isinstance(exception, requests.exceptions.HTTPError):
             status_code = exception.response.status_code
+            ignored_codes = []
             if isinstance(self.ignore_http_error_codes, int) and self.ignore_http_error_codes == status_code:
                 return True
             elif isinstance(self.ignore_http_error_codes, str):
                 ignored_codes = [s.strip().lower() for s in self.ignore_http_error_codes.split(',')]
-                if str(status_code) in ignored_codes or '%sxx' % (status_code // 100) in ignored_codes:
-                    return True
+            elif isinstance(self.ignore_http_error_codes, list):
+                ignored_codes = [str(s).strip().lower() for s in self.ignore_http_error_codes]
+            return str(status_code) in ignored_codes or '%sxx' % (status_code // 100) in ignored_codes
         return False
 
 


### PR DESCRIPTION
This provides the ability for users to ignore chosen HTTP errors.
Close #203 

I'm not 100% sure about the name of this new attribute. Would like a second opinion.

The error handling logic is moved from `worker.py` to within job classes, to make job class features more self-contained, and to prevent overblown `worker.py` code. This is especially relevant in anticipation of "browser" jobs' upgrade.