### PR TITLE
Add dedupe mode to `--gc-cache`

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -168,7 +168,9 @@ class UrlwatchCommand:
         if self.urlwatch_config.features:
             sys.exit(self.show_features())
         if self.urlwatch_config.gc_cache:
-            self.urlwatcher.cache_storage.gc([job.get_guid() for job in self.urlwatcher.jobs])
+            self.urlwatcher.cache_storage.gc(
+                [job.get_guid() for job in self.urlwatcher.jobs], self.urlwatch_config.gc_cache)
+            self.urlwatcher.cache_storage.close()
             sys.exit(0)
         if self.urlwatch_config.edit:
             sys.exit(self.urlwatcher.urls_storage.edit(self.urlwatch_config.urls_yaml_example))

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -103,7 +103,8 @@ class CommandConfig(BaseConfig):
         group.add_argument('--edit-hooks', action='store_true', help='edit hooks script')
         group = parser.add_argument_group('miscellaneous')
         group.add_argument('--features', action='store_true', help='list supported jobs/filters/reporters')
-        group.add_argument('--gc-cache', action='store_true', help='remove old cache entries')
+        group.add_argument('--gc-cache', nargs='?', const='purge', choices=['purge', 'dedupe'],
+                           help='remove old cache entries. Set "dedupe" to only remove duplicate entries.')
 
         args = parser.parse_args()
 


### PR DESCRIPTION
If a job experienced errors, multiple versions of the same job output data would be saved in cache.
E.g.

| id | guid | timestamp | data | tries | etag |
|----|------|-----------|------|-------|------|
| 1 | ... | ... | old_data | 0 | ...|
| 2 | ... | ... | old_data | 1 | ...|
| 3 | ... | ... | old_data | 2 | ...|
| 4 | ... | ... | old_data | 0 | ...|
| 5 | ... | ... | new_data | 0 | ...|
| 6 | ... | ... | new_data | 1 | ...|
| 7 | ... | ... | new_data | 2 | ...|
| 8 | ... | ... | new_data | 3 | ...|
| 9 | ... | ... | new_data | 0 | ...|

It may be desirable to remove old duplicate entries, preserving only the first entry of each version:

| id | guid | timestamp | data | tries | etag |
|----|------|-----------|------|-------|------|
| 1 | ... | ... | old_data | 0 | ...|
| 5 | ... | ... | new_data | 0 | ...|

This pull request adds a "dedupe" option to `--gc-cache`, which does the operation described above.
The old behavior is named "purge" and still the default.