### PR TITLE
Changes wdiff regex to avoid FutureWarning

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -61,8 +61,8 @@ logger = logging.getLogger(__name__)
 
 
 # Regular expressions that match the added/removed markers of GNU wdiff output
-WDIFF_ADDED_RE = r'[{][+].*?[+][}]'
-WDIFF_REMOVED_RE = r'[\[][-].*?[-][]]'
+WDIFF_ADDED_RE = r'{\+.*?\+}'
+WDIFF_REMOVED_RE = r'\[-.*?-\]'
 
 
 class ReporterBase(object, metaclass=TrackSubClasses):


### PR DESCRIPTION
FutureWarning are emitted to inform about future semantical changes around nested sets in
regular expressions. This futureWarning is emitted starting from python 3.7
See: https://docs.python.org/dev/whatsnew/3.7.html#re