### PR TITLE
Add option to compare new data with multiple history versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,9 @@ url: https://example.com/
 compared_versions: 3
 ```
 
-In ths example, changes are only reported if the webpage becomes different from
-the latest three distinct states. Diff is done relative to the closest match.
+In this example, changes are only reported if the webpage becomes different from
+the latest three distinct states. The differences are shown relative to the
+closest match.
 
 
 MIGRATION FROM URLWATCH 1.x

--- a/README.md
+++ b/README.md
@@ -351,6 +351,21 @@ filter:
 ```
 
 
+COMPARE WITH SEVERAL LATEST SNAPSHOTS
+-------------------------------------
+If a webpage frequently changes between several known stable states, it may be
+desirable to have changes reported only if the webpage changes into a new
+unknown state. You can use `compared_versions` to do this.
+
+```yaml
+url: https://example.com/
+compared_versions: 3
+```
+
+In ths example, changes are only reported if the webpage becomes different from
+the latest three distinct states. Diff is done relative to the closest match.
+
+
 MIGRATION FROM URLWATCH 1.x
 ---------------------------
 

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -47,6 +47,7 @@ class JobState(object):
         self.verb = None
         self.old_data = None
         self.new_data = None
+        self.history_data = {}
         self.timestamp = None
         self.exception = None
         self.traceback = None
@@ -54,9 +55,12 @@ class JobState(object):
         self.etag = None
 
     def load(self):
-        self.old_data, self.timestamp, self.tries, self.etag = self.cache_storage.load(self.job, self.job.get_guid())
+        guid = self.job.get_guid()
+        self.old_data, self.timestamp, self.tries, self.etag = self.cache_storage.load(self.job, guid)
         if self.tries is None:
             self.tries = 0
+        if self.job.compared_versions and self.job.compared_versions > 1:
+            self.history_data = self.cache_storage.get_history_data(guid, self.job.compared_versions)
 
     def save(self):
         if self.new_data is None and self.exception is not None:

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -146,7 +146,7 @@ class JobBase(object, metaclass=TrackSubClasses):
 
 class Job(JobBase):
     __required__ = ()
-    __optional__ = ('name', 'filter', 'max_tries', 'diff_tool')
+    __optional__ = ('name', 'filter', 'max_tries', 'diff_tool', 'compared_versions')
 
     # determine if hyperlink "a" tag is used in HtmlReporter
     LOCATION_IS_URL = False

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -490,7 +490,7 @@ class CacheMiniDBStorage(CacheStorage):
         for data, timestamp in CacheEntry.query(self.db, CacheEntry.c.data // CacheEntry.c.timestamp,
                                                 order_by=minidb.columns(CacheEntry.c.timestamp.desc, CacheEntry.c.tries.desc),
                                                 where=(CacheEntry.c.guid == guid)
-                                                & ((CacheEntry.c.tries == 0) | (CacheEntry.c.tries == None))):
+                                                & ((CacheEntry.c.tries == 0) | (CacheEntry.c.tries == None))):  # noqa
             if data not in history:
                 history[data] = timestamp
                 if len(history) >= count:

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -483,6 +483,20 @@ class CacheMiniDBStorage(CacheStorage):
 
         return None, None, 0, None
 
+    def get_history_data(self, guid, count=1):
+        history = {}
+        if count < 1:
+            return history
+        for data, timestamp in CacheEntry.query(self.db, CacheEntry.c.data // CacheEntry.c.timestamp,
+                                                order_by=minidb.columns(CacheEntry.c.timestamp.desc, CacheEntry.c.tries.desc),
+                                                where=(CacheEntry.c.guid == guid)
+                                                & ((CacheEntry.c.tries == 0) | (CacheEntry.c.tries == None))):
+            if data not in history:
+                history[data] = timestamp
+                if len(history) >= count:
+                    break
+        return history
+
     def save(self, job, guid, data, timestamp, tries, etag=None):
         self.db.save(CacheEntry(guid=guid, timestamp=timestamp, data=data, tries=tries, etag=etag))
         self.db.commit()

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -91,7 +91,7 @@ def test_load_hooks_py():
 
 def test_pep8_conformance():
     """Test that we conform to PEP-8."""
-    style = pycodestyle.StyleGuide(ignore=['E501', 'E402'])
+    style = pycodestyle.StyleGuide(ignore=['E501', 'E402', 'W503'])
 
     py_files = [y for x in os.walk(os.path.abspath('.')) for y in glob(os.path.join(x[0], '*.py'))]
     py_files.append(os.path.abspath('urlwatch'))


### PR DESCRIPTION
Add `compared_versions` [int] flag to Job class.
Report "unchanged" if `new_data` is in the last `compared_versions` versions.
If not, compare `new_data` with the closest match as determined by difflib.

Close #22
Close #275

Again, would love a second opinion on better flag/variable names, especially the flag `compared_versions` and the variable `job_state.history_data` (which is a dict of `data: timestamp` items).

Edit: On second thought, it might not resolve #22 directly. I can rebase/reword if needed.