### PR TITLE
Handle empty root node in xpath & css filters

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -416,7 +416,8 @@ class LxmlParser:
             self.data = re.sub(r'^<[?]xml[^>]*[?]>', '', self.data)
             # Retry parsing with XML declaration removed (Fixes #281)
             root = etree.fromstring(self.data, self.parser)
-
+        if root is None:
+            return []
         if self.filter_kind == 'css':
             return root.cssselect(self.expression)
         elif self.filter_kind == 'xpath':


### PR DESCRIPTION
Currently, XPath & CSS filters raise `AttributeError` if `root` is `None` (as result of empty data), which is not helpful to end users.