### PR TITLE
Remove tail text from xpath & css filter results

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -404,7 +404,7 @@ class LxmlParser:
         if isinstance(element, str):
             return element
 
-        return etree.tostring(element, pretty_print=True, method=self.method, encoding='unicode')
+        return etree.tostring(element, pretty_print=True, method=self.method, encoding='unicode', with_tail=False)
 
     def _get_filtered_elements(self):
         try:

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -1,6 +1,8 @@
 from urlwatch.filters import GetElementById
 from urlwatch.filters import GetElementByTag
 from urlwatch.filters import JsonFormatFilter
+from urlwatch.filters import XPathFilter
+from urlwatch.filters import CssFilter
 
 from nose.tools import eq_
 
@@ -62,3 +64,55 @@ def test_json_format_filter_subfilter():
   },
   "field2": "value"
 }""")
+
+
+def test_xpath_elements():
+    xpath_filter = XPathFilter(None, None)
+    result = xpath_filter.filter("""
+    <html><head></head><body>
+    abc
+    <div>foo</div>
+    lmn
+    <span id="bar">bar</span>
+    xyz
+    </body></html>
+    """, "//div | //*[@id='bar']")
+    print(result)
+    eq_(result, """<div>foo</div>
+
+<span id="bar">bar</span>
+""")
+
+
+def test_xpath_text():
+    xpath_filter = XPathFilter(None, None)
+    result = xpath_filter.filter("""
+    <html><head></head><body>
+    abc
+    <div>foo</div>
+    lmn
+    <span id="bar">bar</span>
+    xyz
+    </body></html>
+    """, '//div/text() | //span/@id')
+    print(result)
+    eq_(result, """foo
+bar""")
+
+
+def test_css():
+    css_filter = CssFilter(None, None)
+    result = css_filter.filter("""
+    <html><head></head><body>
+    abc
+    <div>foo</div>
+    lmn
+    <span id="bar">bar</span>
+    xyz
+    </body></html>
+    """, 'div, span')
+    print(result)
+    eq_(result, """<div>foo</div>
+
+<span id="bar">bar</span>
+""")


### PR DESCRIPTION
lxml does not use special text nodes, but instead uses `text` and `tail` attributes to handle text.
`lxml.etree.tostring` includes tail text by default, so
```html
<html><head></head><body>
<div>foo</div>
bar
</body></html>
```
filtered with `xpath://div` or `css:div`
returns
```html
<div>foo</div>
bar
```
rather than
```html
<div>foo</div>
```

This is not the standard XPath or CSS selector behavior users would expect.
Tail text should be removed, so the second result is returned.