### PR TITLE
Unify JSON pretty print format

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -195,7 +195,7 @@ class JsonFormatFilter(FilterBase):
         if subfilter is not None:
             indentation = int(subfilter)
         parsed_json = json.loads(data)
-        return json.dumps(parsed_json, sort_keys=True, indent=indentation)
+        return json.dumps(parsed_json, sort_keys=True, indent=indentation, separators=(',', ': '))
 
 
 class GrepFilter(FilterBase):


### PR DESCRIPTION
Explicitly specify `separators` in `json.dumps` to unify pretty print behavior across different Python versions.
Otherwise, Python 3.3 behaves differently from later versions.

See https://docs.python.org/3/library/json.html#json.dump