### PR TITLE
Unify filter tests

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -195,7 +195,7 @@ class JsonFormatFilter(FilterBase):
         if subfilter is not None:
             indentation = int(subfilter)
         parsed_json = json.loads(data)
-        return json.dumps(parsed_json, sort_keys=True, indent=indentation)
+        return json.dumps(parsed_json, sort_keys=True, indent=indentation, separators=(',', ': '))
 
 
 class GrepFilter(FilterBase):

--- a/test/data/filter_tests.yaml
+++ b/test/data/filter_tests.yaml
@@ -1,0 +1,128 @@
+# <test-name>:
+#   filter: <specs-of-a-single-filter-as-string-or-mapping>
+#   data: |
+#       Input data as block scalar (string).
+#       Use the literal style (starts with "|") for better readability.
+#       Use a chomping indicator (-/+) to control trailing newlines.
+#       Ref:
+#         https://yaml.org/spec/1.2/spec.html#id2795688
+#         https://yaml.org/spec/1.2/spec.html#id2794534
+#   expected_result: |
+#       <Expected filtered data>
+element_by_tag:
+    filter: element-by-tag:body
+    data: |
+        <html><head></head><body>foo</body></html>
+    expected_result: |-
+        <body>foo</body>
+element_by_tag_nested:
+    filter: element-by-tag:div
+    data: |
+        <html><head></head><body>
+        <div>foo</div>
+        <div>bar</div>
+        </body></html>
+    expected_result: |-
+        <div>foo</div><div>bar</div>
+element_by_id:
+    filter: element-by-id:bar
+    data: |
+        <html><head></head><body>
+        <div id="foo">asdf <span>bar</span></div>
+        <div id="bar">asdf <span>bar</span> hoho</div>
+        </body></html>
+    expected_result: |-
+        <div id="bar">asdf <span>bar</span> hoho</div>
+element_by_class:
+    filter: element-by-class:foo
+    data: |
+        <html><head></head><body>
+        <div class="foo">foo</div>
+        <div class="bar">bar</div>
+        </body></html>
+    expected_result: |-
+        <div class="foo">foo</div>
+xpath_elements:
+    filter: xpath://div | //*[@id="bar"]
+    data: |
+        <html><head></head><body>
+        <div>foo</div>
+        <div id="bar">bar</div>
+        </body></html>
+    expected_result: |
+        <div>foo</div>
+        
+        <div id="bar">bar</div>
+xpath_text:
+    filter: xpath://div[1]/text() | //div[2]/@id
+    data: |
+        <html><head></head><body>
+        <div>foo</div>
+        <div id="bar">bar</div>
+        </body></html>
+    expected_result: |-
+        foo
+        bar
+css:
+    filter: css:div
+    data: |
+        <html><head></head><body>
+        <div>foo</div>
+        <div>bar</div>
+        </body></html>
+    expected_result: |
+        <div>foo</div>
+        
+        <div>bar</div>
+grep:
+    filter: grep:blue
+    data: |
+        The rose is red;
+        the violet's blue.
+        Sugar is sweet,
+        and so are you.
+    expected_result: |-
+        the violet's blue.
+grep_with_comma:
+    filter: grep:\054
+    data: |
+        The rose is red;
+        the violet's blue.
+        Sugar is sweet,
+        and so are you.
+    expected_result: |-
+        Sugar is sweet,
+json_format:
+    filter: format-json
+    data: |
+        {"field1": {"f1.1": "value"},"field2": "value"}
+    expected_result: |-
+        {
+            "field1": {
+                "f1.1": "value"
+            },
+            "field2": "value"
+        }
+json_format_subfilter:
+    filter: format-json:2
+    data: |
+        {"field1": {"f1.1": "value"},"field2": "value"}
+    expected_result: |-
+        {
+          "field1": {
+            "f1.1": "value"
+          },
+          "field2": "value"
+        }
+sha1:
+    filter: sha1sum
+    data: 1234567890abcdefg
+    expected_result: 8417680c09644df743d7cea1366fbe13a31b2d5e
+hexdump:
+    filter: hexdump
+    data: |
+        Hello world!
+        你好，世界！
+    expected_result: |-
+        48 65 6c 6c 6f 20 77 6f 72 6c 64 21 0a e4 bd a0  Hello world!....
+        e5 a5 bd ef bc 8c e4 b8 96 e7 95 8c ef bc 81 0a  ................

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -1,118 +1,38 @@
-from urlwatch.filters import GetElementById
-from urlwatch.filters import GetElementByTag
-from urlwatch.filters import JsonFormatFilter
-from urlwatch.filters import XPathFilter
-from urlwatch.filters import CssFilter
-
+import os
+import logging
+import yaml
+from urlwatch.filters import FilterBase
 from nose.tools import eq_
 
-
-def test_get_element_by_id():
-    get_element_by_id = GetElementById(None, None)
-    result = get_element_by_id.filter("""
-    <html><head></head><body>
-    <div id="foo">asdf <span>bar</span></div>
-    <div id="bar">asdf <span>bar</span> hoho</div>
-    </body></html>
-    """, 'bar')
-    print(result)
-    eq_(result, '<div id="bar">asdf <span>bar</span> hoho</div>')
+logger = logging.getLogger(__name__)
 
 
-def test_get_element_by_tag():
-    get_element_by_tag = GetElementByTag(None, None)
-    result = get_element_by_tag.filter("""
-    <html><head></head><body>foo</body></html>
-    """, 'body')
-    print(result)
-    eq_(result, '<body>foo</body>')
+def test_filters():
+    def check_filter(test_name):
+        filter = filter_tests[test_name]['filter']
+        data = filter_tests[test_name]['data']
+        expected_result = filter_tests[test_name]['expected_result']
+        if isinstance(filter, dict):
+            key = next(iter(filter))
+            kind, subfilter = key, filter[key]
+        elif isinstance(filter, str):
+            if ',' in filter:
+                raise ValueError('Only single filter allowed in this test')
+            elif ':' in filter:
+                kind, subfilter = filter.split(':', 1)
+            else:
+                kind = filter
+                subfilter = None
+        logger.info('filter kind: %s, subfilter: %s', kind, subfilter)
+        filtercls = FilterBase.__subclasses__.get(kind)
+        if filtercls is None:
+            raise ValueError('Unknown filter kind: %s:%s' % (filter_kind, subfilter))
+        result = filtercls(None, None).filter(data, subfilter)
+        logger.debug('Expected result:\n%s', expected_result)
+        logger.debug('Actual result:\n%s', result)
+        eq_(result, expected_result)
 
-
-def test_get_element_by_tag_nested():
-    get_element_by_tag = GetElementByTag(None, None)
-    result = get_element_by_tag.filter("""
-    <html><head></head><body>
-    <div>foo</div>
-    <div>bar</div>
-    </body></html>
-    """, 'div')
-    print(result)
-    eq_(result, """<div>foo</div><div>bar</div>""")
-
-
-def test_json_format_filter():
-    json_format_filter = JsonFormatFilter(None, None)
-    result = json_format_filter.filter(
-        """{"field1": {"f1.1": "value"},"field2": "value"}""")
-    print(result)
-    eq_(result, """{
-    "field1": {
-        "f1.1": "value"
-    },
-    "field2": "value"
-}""")
-
-
-def test_json_format_filter_subfilter():
-    json_format_filter = JsonFormatFilter(None, None)
-    result = json_format_filter.filter(
-        """{"field1": {"f1.1": "value"},"field2": "value"}""", "2")
-    print(result)
-    eq_(result, """{
-  "field1": {
-    "f1.1": "value"
-  },
-  "field2": "value"
-}""")
-
-
-def test_xpath_elements():
-    xpath_filter = XPathFilter(None, None)
-    result = xpath_filter.filter("""
-    <html><head></head><body>
-    abc
-    <div>foo</div>
-    lmn
-    <span id="bar">bar</span>
-    xyz
-    </body></html>
-    """, "//div | //*[@id='bar']")
-    print(result)
-    eq_(result, """<div>foo</div>
-
-<span id="bar">bar</span>
-""")
-
-
-def test_xpath_text():
-    xpath_filter = XPathFilter(None, None)
-    result = xpath_filter.filter("""
-    <html><head></head><body>
-    abc
-    <div>foo</div>
-    lmn
-    <span id="bar">bar</span>
-    xyz
-    </body></html>
-    """, '//div/text() | //span/@id')
-    print(result)
-    eq_(result, """foo
-bar""")
-
-
-def test_css():
-    css_filter = CssFilter(None, None)
-    result = css_filter.filter("""
-    <html><head></head><body>
-    abc
-    <div>foo</div>
-    lmn
-    <span id="bar">bar</span>
-    xyz
-    </body></html>
-    """, 'div, span')
-    print(result)
-    eq_(result, """<div>foo</div>
-
-<span id="bar">bar</span>
-""")
+    with open(os.path.join(os.path.dirname(__file__), 'data/filter_tests.yaml'), 'r', encoding='utf8') as fp:
+        filter_tests = yaml.load(fp)
+    for test_name in filter_tests:
+        yield check_filter, test_name


### PR DESCRIPTION
Use a test generator and a YAML file as a general framework for all filter tests.
Add missing tests for all named filters.

This is more cosmetics, and not strictly necessary. But personally, I find this improves readability of test data by a lot, and make new filter tests much easier to write.

This PR includes/depends on #343.
If either this or #333 is merged, the other had better wait to add a new test case for #333.