### PR TITLE
Render browser jobs' web pages asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Optional dependencies (install via `python3 -m pip install <packagename>`):
   * Pushover reporter: [chump](https://github.com/karanlyons/chump/)
   * Pushbullet reporter: [pushbullet.py](https://github.com/randomchars/pushbullet.py)
   * Stdout reporter with color on Windows: [colorama](https://github.com/tartley/colorama)
-  * "browser" job kind: [requests-html](https://html.python-requests.org)
+  * "browser" job kind: [pyppeteer](https://github.com/miyakogi/pyppeteer), Python 3.6 or newer
   * Unit testing: [pycodestyle](http://pycodestyle.pycqa.org/en/latest/)
 
 
@@ -289,7 +289,7 @@ BROWSER
 -------
 
 If the webpage you are trying to watch runs client-side JavaScript to
-render the page, [Requests-HTML](http://html.python-requests.org) can
+render the page, [Pyppeteer](https://github.com/miyakogi/pyppeteer) can
 now be used to render the page in a headless Chromium instance first
 and then use the HTML of the resulting page.
 

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -127,13 +127,16 @@ class UrlwatchCommand:
             # Force re-retrieval of job, as we're testing filters
             job.ignore_cached = True
 
-        job_state = JobState(self.urlwatcher.cache_storage, job)
+        resources = {}
+        job.request_resources(resources)
+        job_state = JobState(self.urlwatcher.cache_storage, resources, job)
         job_state.process()
         if job_state.exception is not None:
             raise job_state.exception
         print(job_state.new_data)
         # We do not save the job state or job on purpose here, since we are possibly modifying the job
         # (ignore_cached) and we do not want to store the newly-retrieved data yet (filter testing)
+        job.release_resources(resources)
         return 0
 
     def modify_urls(self):

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -41,8 +41,9 @@ logger = logging.getLogger(__name__)
 
 
 class JobState(object):
-    def __init__(self, cache_storage, job):
+    def __init__(self, cache_storage, resources, job):
         self.cache_storage = cache_storage
+        self.resources = resources
         self.job = job
         self.verb = None
         self.old_data = None

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -30,6 +30,7 @@
 
 import concurrent.futures
 import logging
+from contextlib import ExitStack
 
 import requests
 
@@ -56,53 +57,52 @@ def run_jobs(urlwatcher):
             for job in urlwatcher.jobs]
     report = urlwatcher.report
 
-    resources = {}
-    for job in jobs:
-        job.request_resources(resources)
+    with ExitStack() as exit_stack:
+        resources = {}
+        for job in jobs:
+            job.request_resources(resources)
+            exit_stack.callback(job.release_resources, resources)
 
-    logger.debug('Processing %d jobs', len(jobs))
-    for job_state in run_parallel(lambda job_state: job_state.process(),
-                                  (JobState(cache_storage, resources, job) for job in jobs)):
-        logger.debug('Job finished: %s', job_state.job)
+        logger.debug('Processing %d jobs', len(jobs))
+        for job_state in run_parallel(lambda job_state: job_state.process(),
+                                      (JobState(cache_storage, resources, job) for job in jobs)):
+            logger.debug('Job finished: %s', job_state.job)
 
-        if not job_state.job.max_tries:
-            max_tries = 0
-        else:
-            max_tries = job_state.job.max_tries
-        logger.debug('Using max_tries of %i for %s', max_tries, job_state.job)
+            if not job_state.job.max_tries:
+                max_tries = 0
+            else:
+                max_tries = job_state.job.max_tries
+            logger.debug('Using max_tries of %i for %s', max_tries, job_state.job)
 
-        if job_state.exception is not None:
-            if job_state.error_ignored:
-                logger.info('Error while executing job %s ignored due to job config', job_state.job)
-            elif isinstance(job_state.exception, NotModifiedError):
-                logger.info('Job %s has not changed (HTTP 304)', job_state.job)
-                report.unchanged(job_state)
-                if job_state.tries > 0:
+            if job_state.exception is not None:
+                if job_state.error_ignored:
+                    logger.info('Error while executing job %s ignored due to job config', job_state.job)
+                elif isinstance(job_state.exception, NotModifiedError):
+                    logger.info('Job %s has not changed (HTTP 304)', job_state.job)
+                    report.unchanged(job_state)
+                    if job_state.tries > 0:
+                        job_state.tries = 0
+                        job_state.save()
+                elif job_state.tries < max_tries:
+                    logger.debug('This was try %i of %i for job %s', job_state.tries,
+                                 max_tries, job_state.job)
+                    job_state.save()
+                elif job_state.tries >= max_tries:
+                    logger.debug('We are now at %i tries ', job_state.tries)
+                    job_state.save()
+                    report.error(job_state)
+
+            elif job_state.old_data is not None:
+                if job_state.old_data.splitlines() != job_state.new_data.splitlines():
+                    report.changed(job_state)
                     job_state.tries = 0
                     job_state.save()
-            elif job_state.tries < max_tries:
-                logger.debug('This was try %i of %i for job %s', job_state.tries,
-                             max_tries, job_state.job)
-                job_state.save()
-            elif job_state.tries >= max_tries:
-                logger.debug('We are now at %i tries ', job_state.tries)
-                job_state.save()
-                report.error(job_state)
-
-        elif job_state.old_data is not None:
-            if job_state.old_data.splitlines() != job_state.new_data.splitlines():
-                report.changed(job_state)
+                else:
+                    report.unchanged(job_state)
+                    if job_state.tries > 0:
+                        job_state.tries = 0
+                        job_state.save()
+            else:
+                report.new(job_state)
                 job_state.tries = 0
                 job_state.save()
-            else:
-                report.unchanged(job_state)
-                if job_state.tries > 0:
-                    job_state.tries = 0
-                    job_state.save()
-        else:
-            report.new(job_state)
-            job_state.tries = 0
-            job_state.save()
-
-    for job in jobs:
-        job.release_resources(resources)

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -56,9 +56,13 @@ def run_jobs(urlwatcher):
             for job in urlwatcher.jobs]
     report = urlwatcher.report
 
+    resources = {}
+    for job in jobs:
+        job.request_resources(resources)
+
     logger.debug('Processing %d jobs', len(jobs))
     for job_state in run_parallel(lambda job_state: job_state.process(),
-                                  (JobState(cache_storage, job) for job in jobs)):
+                                  (JobState(cache_storage, resources, job) for job in jobs)):
         logger.debug('Job finished: %s', job_state.job)
 
         if not job_state.job.max_tries:
@@ -99,3 +103,6 @@ def run_jobs(urlwatcher):
             report.new(job_state)
             job_state.tries = 0
             job_state.save()
+
+    for job in jobs:
+        job.release_resources(resources)


### PR DESCRIPTION
An alternative of #310.

> This version introduces even fewer changes. No AsyncJob class. No centrally managed event loop. No state info in any job class.
> 
> Instead, it adds two new methods request_resources and release_resources to JobBase. They are called before and after jobs are run (e.g. the main loop in worker.py) respectively.
> The resource object (just a dict) is supplied to JobState.__init__, and can then be used when processing jobs (e.g. in job.retrieve).
> 
> Using these two new methods, BrowserJob treats the browser instance and the event loop (together with loop_thread) as shared resources, and manages them itself.
> Future new job classes that use coroutines can create and mange their own independent event loop and "loop thread".

---

Things that still bug me a bit:

* Maybe not a big deal (for now at least), but using just a dict to store and handle resources feels a bit ad hoc.

* If any `request_resources` call fails, the entire run would fail. Ideally, exceptions should be caught, and only jobs that need such failed resources would fail.
I could just catch all exceptions in `BrowserJob.request_resources` for now, but it's best to have a general mechanism to handle resource exceptions for all future and custom job classes (ones in `hooks.py`).