### PR TITLE
Fix --test-filter behaviour when job not found

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -118,10 +118,10 @@ class UrlwatchCommand:
 
     def test_filter(self):
         job = self._find_job(self.urlwatch_config.test_filter)
-        job = job.with_defaults(self.urlwatcher.config_storage.config)
         if job is None:
             print('Not found: %r' % (self.urlwatch_config.test_filter,))
             return 1
+        job = job.with_defaults(self.urlwatcher.config_storage.config)
 
         if isinstance(job, UrlJob):
             # Force re-retrieval of job, as we're testing filters


### PR DESCRIPTION
This PR addresses the second part of #365.