### PR TITLE
Add simple replace filter example

### DIFF
--- a/share/urlwatch/examples/hooks.py.example
+++ b/share/urlwatch/examples/hooks.py.example
@@ -115,3 +115,10 @@ class CustomHtmlFileReporter(reporters.HtmlReporter):
     def submit(self):
         with open(self.config['filename'], 'w') as fp:
             fp.write('\n'.join(super().submit()))
+
+
+class SimpleReplaceFilter(filters.FilterBase):
+    __kind__ = 'simple-replace-filter'
+    def filter(self, data, subfilter=None):
+        data = re.sub(subfilter.get('search'), subfilter.get('replace'), data)
+        return data

--- a/share/urlwatch/examples/urls.yaml.example
+++ b/share/urlwatch/examples/urls.yaml.example
@@ -45,5 +45,5 @@ data:
 url: "http://example.com/foo"
 filter:
   - simple-replace-filter:
-        search: "\<br\>"
+        search: "<br>"
         replace: "\n"


### PR DESCRIPTION
The example is not only instructive but actually even useful, e.g. to insert linebreaks if they are missing in the HTML.