### PR TITLE
Add support for insecure SMTP password storage (Fixes #277)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ These are the keys you need to configure (see #158):
 - `report/email/from`: `your.username@gmail.com` (edit accordingly)
 - `report/email/method`: `smtp`
 - `report/email/smtp/host`: `smtp.gmail.com`
-- `report/email/smtp/keyring`: `true`
+- `report/email/smtp/auth`: `true`
 - `report/email/smtp/port`: `587`
 - `report/email/smtp/starttls`: `true`
 - `report/email/to`: The e-mail address you want to send reports to
@@ -350,13 +350,37 @@ These are the keys you need to configure:
 - `report/email/method`: `smtp`
 - `report/email/smtp/host`: `email-smtp.us-west-2.amazonaws.com` (edit accordingly)
 - `report/email/smtp/user`: `ABCDEFGHIJ1234567890` (edit accordingly)
-- `report/email/smtp/keyring`: `true`
+- `report/email/smtp/auth`: `true`
 - `report/email/smtp/port`: `587` (25 or 465 also work)
 - `report/email/smtp/starttls`: `true`
 - `report/email/to`: The e-mail address you want to send reports to
 
 The password is not stored in the config file, but in your keychain. To store
 the password, run: `urlwatch --smtp-login` and enter your password.
+
+
+SMTP LOGIN WITHOUT KEYRING
+--------------------------
+
+If for whatever reason you cannot use a keyring to store your password
+(for example, when using it from a `cron` job)
+you can also set the `insecure_password` option in the SMTP config:
+
+- `report/email/smtp/auth`: `true`
+- `report/email/smtp/insecure_password`: `secret123`
+
+The `insecure_password` key will be preferred over the data stored in
+the keyring. Please note that as the name says, storing the password
+as plaintext in the configuration is insecure and bad practice, but
+for an e-mail account that's only dedicated for sending mails this
+might be a way. **Never ever use this with your your primary
+e-mail account!** Seriously! Create a throw-away GMail (or other)
+account just for sending out those e-mails or use local `sendmail` with
+a mail server configured instead of relying on SMTP and password auth.
+
+Note that this makes it really easy for your password to be picked up
+by software running on your machine, by other users logged into the system
+and/or for the password to appear in log files accidentally.
 
 
 TESTING FILTERS

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -256,8 +256,8 @@ class UrlwatchCommand:
                 print('Please set the method to SMTP for the e-mail reporter.')
                 success = False
 
-            if not smtp_config['keyring']:
-                print('Keyring authentication must be enabled for SMTP.')
+            if not smtp_config.get('auth', smtp_config.get('keyring', False)):
+                print('Authentication must be enabled for SMTP.')
                 success = False
 
             smtp_hostname = smtp_config['host']
@@ -272,6 +272,10 @@ class UrlwatchCommand:
 
             if not success:
                 sys.exit(1)
+
+            if 'insecure_password' in smtp_config:
+                print('The password is already set in the config (key "insecure_password").')
+                sys.exit(0)
 
             if have_password(smtp_hostname, smtp_username):
                 message = 'Password for %s / %s already set, update? [y/N] ' % (smtp_username, smtp_hostname)

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -72,12 +72,13 @@ class Mailer(object):
 
 
 class SMTPMailer(Mailer):
-    def __init__(self, smtp_user, smtp_server, smtp_port, tls, auth):
+    def __init__(self, smtp_user, smtp_server, smtp_port, tls, auth, insecure_password=None):
         self.smtp_server = smtp_server
         self.smtp_user = smtp_user
         self.smtp_port = smtp_port
         self.tls = tls
         self.auth = auth
+        self.insecure_password = insecure_password
 
     def send(self, msg):
         s = smtplib.SMTP(self.smtp_server, self.smtp_port)
@@ -86,10 +87,13 @@ class SMTPMailer(Mailer):
         if self.tls:
             s.starttls()
 
-        if self.auth and keyring is not None:
-            passwd = keyring.get_password(self.smtp_server, self.smtp_user)
-            if passwd is None:
-                raise ValueError('No password available in keyring for {}, {}'.format(self.smtp_server, self.smtp_user))
+        if self.auth:
+            if self.insecure_password:
+                passwd = self.insecure_password
+            elif keyring is not None:
+                passwd = keyring.get_password(self.smtp_server, self.smtp_user)
+                if passwd is None:
+                    raise ValueError('No password available in keyring for {}, {}'.format(self.smtp_server, self.smtp_user))
             s.login(self.smtp_user, passwd)
 
         s.sendmail(msg['From'], [msg['To']], msg.as_string())

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -397,8 +397,13 @@ class EMailReporter(TextReporter):
             return
         if self.config['method'] == "smtp":
             smtp_user = self.config['smtp'].get('user', None) or self.config['from']
+            # Legacy support: The current smtp "auth" setting was previously called "keyring"
+            if 'keyring' in self.config['smtp']:
+                logger.info('The SMTP config key "keyring" is now called "auth".')
+            use_auth = self.config['smtp'].get('auth', self.config['smtp'].get('keyring', False))
             mailer = SMTPMailer(smtp_user, self.config['smtp']['host'], self.config['smtp']['port'],
-                                self.config['smtp']['starttls'], self.config['smtp']['keyring'])
+                                self.config['smtp']['starttls'], use_auth,
+                                self.config['smtp'].get('insecure_password'))
         elif self.config['method'] == "sendmail":
             mailer = SendmailMailer(self.config['sendmail']['path'])
         else:

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -81,7 +81,7 @@ DEFAULT_CONFIG = {
                 'user': '',
                 'port': 25,
                 'starttls': True,
-                'keyring': True,
+                'auth': True,
             },
             'sendmail': {
                 'path': 'sendmail',

--- a/test/data/urlwatch.yaml
+++ b/test/data/urlwatch.yaml
@@ -12,7 +12,7 @@ report:
       path: sendmail
     smtp:
       host: localhost
-      keyring: true
+      auth: true
       port: 25
       starttls: true
     subject: '{count} changes: {jobs}'


### PR DESCRIPTION
As requested in #277, here's a possible way to supply the password as plain text in an insecure way to avoid having to deal with keyring access in cron.