### PR TITLE
format-json filter now handles utf-8 correctly

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -196,7 +196,7 @@ class JsonFormatFilter(FilterBase):
         if subfilter is not None:
             indentation = int(subfilter)
         parsed_json = json.loads(data)
-        return json.dumps(parsed_json, sort_keys=True, indent=indentation, separators=(',', ': '))
+        return json.dumps(parsed_json, ensure_ascii=False, sort_keys=True, indent=indentation, separators=(',', ': '))
 
 
 class GrepFilter(FilterBase):


### PR DESCRIPTION
The world is moving to UTF-8 (see https://discuss.python.org/t/pep-597-use-utf-8-for-default-text-file-encoding/1819).

The current filter outputs non-ASCII characters as escaped (e.g. '–' is replaced by '\u2013') which makes some text very hard to read.  json.dumps forces a transformation of non-ASCII characters, which is no longer needed on modern computers.

Documentation: https://docs.python.org/3/library/json.html#json.dump