### PR TITLE
New filter 'pdf2text' to extract text from PDF

### DIFF
--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -38,7 +38,7 @@ Where ``<packagename>`` is one of the following:
 +-------------------------+---------------------------------------------------------------------+
 | Feature                 | Python package(s) to install                                        |
 +=========================+=====================================================================+
-| Pushover reporter       | `chump <https://github.com/karanlyons/chump/>`__                    |
+| Pushover reporter       | `chump <https://github.com/karanlyons/chump>`__                     |
 +-------------------------+---------------------------------------------------------------------+
 | Pushbullet reporter     | `pushbullet.py <https://github.com/randomchars/pushbullet.py>`__    |
 +-------------------------+---------------------------------------------------------------------+
@@ -55,5 +55,8 @@ Where ``<packagename>`` is one of the following:
 | `beautify` filter       | `beautifulsoup4 <https://pypi.org/project/beautifulsoup4/>`__,      |
 |                         | `jsbeautifier <https://pypi.org/project/jsbeautifier/>`__ and       |
 |                         | `cssbeautifier <https://pypi.org/project/cssbeautifier/>`__         |
++-------------------------+---------------------------------------------------------------------+
+| `pdf2text` filter       | `pdftotext <https://github.com/jalan/pdftotext>`__ and              |
+|                         | its OS-specific dependencies (see the above link)                   |
 +-------------------------+---------------------------------------------------------------------+
 

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -37,6 +37,7 @@ At the moment, the following filters are built-in:
 - **grepi**: Filter which removes lines matching a regular expression
 - **hexdump**: Convert binary data to hex dump format
 - **html2text**: Convert HTML to plaintext
+- **pdf2text**: Convert PDF to plaintext
 - **ical2text**: Convert iCalendar to plaintext
 - **re.sub**: Replace text with regular expressions using Python's re.sub
 - **sha1sum**: Calculate the SHA-1 checksum of the content
@@ -209,6 +210,30 @@ tag in its results:
      - css:
          selector: 'body'
          exclude: 'a'
+
+
+Filtering PDF documents
+-----------------------
+
+To monitor the text of a PDF file, you use the `pdf2text` filter. It requires 
+the installation of the `pdftotext <https://github.com/jalan/pdftotext/blob/master/README.md#pdftotext>`__
+library and any of its OS-specific dependencies (see 
+`website <https://github.com/jalan/pdftotext/blob/master/README.md#os-dependencies>`__.
+
+.. code:: yaml
+
+   url: https://example.net/sample.pdf
+   filter: pdf2text
+
+
+If the PDF file is password protected, you can specify its password:
+
+.. code:: yaml
+
+   url: https://example.net/sample.pdf
+   filter: 
+    - pdf2text:
+        password: pdfpassword
 
 
 Line-based sorting of webpage content

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -206,16 +206,17 @@ class Pdf2TextFilter(FilterBase):
     # Note: check pdftotext website for OS-specific dependencies for install
 
     __kind__ = 'pdf2text'
+    __uses_bytes__ = True
 
     def filter(self, data, subfilter=None):
         # data must be bytes
+        if not isinstance(data, bytes):
+            raise ValueError('The pdf2text filter needs bytes input (is it the first filter?)')
 
         if subfilter is None:
             password = ''
         elif isinstance(subfilter, dict):
             password = subfilter['password']
-        elif isinstance(subfilter, str):
-            password = subfilter
         import pdftotext
         import io
         return '\n\n'.join(pdftotext.PDF(io.BytesIO(data), password=password))

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -198,6 +198,29 @@ class Html2TextFilter(FilterBase):
         return html2text(data, method=method, options=options)
 
 
+class Pdf2TextFilter(FilterBase):
+    """Convert PDF to plaintext"""
+    # Requires data to be in bytes (not unicode)
+    # Dependency: pdftotext (https://github.com/jalan/pdftotext), itself based
+    # on poppler (https://poppler.freedesktop.org/)
+    # Note: check pdftotext website for OS-specific dependencies for install
+
+    __kind__ = 'pdf2text'
+
+    def filter(self, data, subfilter=None):
+        # data must be bytes
+
+        if subfilter is None:
+            password = ''
+        elif isinstance(subfilter, dict):
+            password = subfilter['password']
+        elif isinstance(subfilter, str):
+            password = subfilter
+        import pdftotext
+        import io
+        return '\n\n'.join(pdftotext.PDF(io.BytesIO(data), password=password))
+
+
 class Ical2TextFilter(FilterBase):
     """Convert iCalendar to plaintext"""
 

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -89,6 +89,11 @@ class FilterBase(object, metaclass=TrackSubClasses):
             raise ValueError('Unknown filter kind: %s:%s' % (filter_kind, subfilter))
         return filtercls(state.job, state).filter(data, subfilter)
 
+    @classmethod
+    def is_bytes_filter(cls, filter):
+        return (filter in [name for name, class_ in FilterBase.__subclasses__.items()
+                           if getattr(class_, '__uses_bytes__', False)])
+
     def match(self):
         return False
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -293,8 +293,6 @@ class UrlJob(Job):
 
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
-        print(f'{next(iter(self.filter[0]))=}')
-        print(f'{list(self.filter[0])=}')
         if self.filter and (FilterBase.is_bytes_filter(self.filter)
                             or FilterBase.is_bytes_filter(next(iter(self.filter[0])))):
             return response.content

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -199,11 +199,9 @@ class ShellJob(Job):
         if result != 0:
             raise ShellError(result)
 
-        bytes_filters = [name for name, class_ in FilterBase.__subclasses__.items()
-                         if getattr(class_, '__uses_bytes__', False)]
-        if self.filter and (self.filter in bytes_filters or self.filter[0] in bytes_filters):
-            # The first filter is a bytes filter, return content in bytes instead of in unicode
-            # as that's what's required by the library used by that filter
+        # If the first filter is a bytes filter, return content in bytes instead of in unicode
+        # as that's what's required by the library used by that filter
+        if self.filter and (FilterBase(self, self.filter) or FilterBase(self, self.filter[0])):
             return stdout_data
 
         return stdout_data.decode('utf-8')
@@ -292,11 +290,9 @@ class UrlJob(Job):
         # Save ETag from response into job_state, which will be saved in cache
         job_state.etag = response.headers.get('ETag')
 
-        bytes_filters = [name for name, class_ in FilterBase.__subclasses__.items()
-                         if getattr(class_, '__uses_bytes__', False)]
-        if self.filter and (self.filter in bytes_filters or self.filter[0] in bytes_filters):
-            # The first filter is a bytes filter, return content in bytes instead of in unicode
-            # as that's what's required by the library used by that filter
+        # If the first filter is a bytes filter, return content in bytes instead of in unicode
+        # as that's what's required by the library used by that filter
+        if self.filter and (FilterBase(self, self.filter) or FilterBase(self, self.filter[0])):
             return response.content
 
         # If we can't find the encoding in the headers, requests gets all

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -199,6 +199,13 @@ class ShellJob(Job):
         if result != 0:
             raise ShellError(result)
 
+        bytes_filters = [name for name, class_ in FilterBase.__subclasses__.items()
+                         if getattr(class_, '__uses_bytes__', False)]
+        if self.filter and (self.filter in bytes_filters or self.filter[0] in bytes_filters):
+            # The first filter is a bytes filter, return content in bytes instead of in unicode
+            # as that's what's required by the library used by that filter
+            return stdout_data
+
         return stdout_data.decode('utf-8')
 
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -201,7 +201,8 @@ class ShellJob(Job):
 
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
-        if self.filter and (FilterBase(self, self.filter) or FilterBase(self, self.filter[0])):
+        if self.filter and (FilterBase.is_bytes_filter(self.filter)
+                            or any(FilterBase.is_bytes_filter(filter) for filter in self.filter[0])):
             return stdout_data
 
         return stdout_data.decode('utf-8')
@@ -292,7 +293,8 @@ class UrlJob(Job):
 
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
-        if self.filter and (FilterBase(self, self.filter) or FilterBase(self, self.filter[0])):
+        if self.filter and (FilterBase.is_bytes_filter(self.filter)
+                            or any(FilterBase.is_bytes_filter(filter) for filter in self.filter[0])):
             return response.content
 
         # If we can't find the encoding in the headers, requests gets all

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -284,6 +284,11 @@ class UrlJob(Job):
         # Save ETag from response into job_state, which will be saved in cache
         job_state.etag = response.headers.get('ETag')
 
+        # If 'pdf2text' filter is selected, return content in bytes instead of in unicode
+        # as that's what's required by the library used by that filter
+        if self.filter and ('pdf2text' in self.filter or any('pdf2text' in subfilter for subfilter in self.filter)):
+            return response.content
+
         # If we can't find the encoding in the headers, requests gets all
         # old-RFC-y and assumes ISO-8859-1 instead of UTF-8. Use the old
         # urlwatch behavior and try UTF-8 decoding first.

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -202,7 +202,7 @@ class ShellJob(Job):
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
         if self.filter and (FilterBase.is_bytes_filter(self.filter)
-                            or any(FilterBase.is_bytes_filter(filter) for filter in self.filter[0])):
+                            or FilterBase.is_bytes_filter(next(iter(self.filter[0])))):
             return stdout_data
 
         return stdout_data.decode('utf-8')
@@ -294,7 +294,7 @@ class UrlJob(Job):
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
         if self.filter and (FilterBase.is_bytes_filter(self.filter)
-                            or any(FilterBase.is_bytes_filter(filter) for filter in self.filter[0])):
+                            or FilterBase.is_bytes_filter(next(iter(self.filter[0])))):
             return response.content
 
         # If we can't find the encoding in the headers, requests gets all


### PR DESCRIPTION
A filter 'pdf2text' is created to extract text from a PDF file; this allows tracking of changes to the contents of PDF files.

It is based on the pdftotext library (https://github.com/jalan/pdftotext), which in turn is based on poppler (https://poppler.freedesktop.org/).  README has been updated with the additional requirements.

It only works on bytes, so I also had to modify code in the job.py library: if this filter is specified, a bytes object is returned instead of a str.  Longer term this probably should be a more generic option.