### PR TITLE
Correct issue with terminal url selector picking up ending bracket

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -99,7 +99,7 @@ class UrlwatchCommand:
                 pretty_name = job.pretty_name()
                 location = job.get_location()
                 if pretty_name != location:
-                    print('%d: %s (%s)' % (idx + 1, pretty_name, location))
+                    print('%d: %s ( %s )' % (idx + 1, pretty_name, location))
                 else:
                     print('%d: %s' % (idx + 1, pretty_name))
         return 0

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -249,7 +249,7 @@ class TextReporter(ReporterBase):
                 pretty_name = job_state.job.pretty_name()
                 location = job_state.job.get_location()
                 if pretty_name != location:
-                    location = '%s (%s)' % (pretty_name, location)
+                    location = '%s ( %s )' % (pretty_name, location)
                 yield ': '.join((job_state.verb.upper(), location))
             return
 
@@ -296,7 +296,7 @@ class TextReporter(ReporterBase):
         pretty_name = job_state.job.pretty_name()
         location = job_state.job.get_location()
         if pretty_name != location:
-            location = '%s (%s)' % (pretty_name, location)
+            location = '%s ( %s )' % (pretty_name, location)
 
         pretty_summary = ': '.join((job_state.verb.upper(), pretty_name))
         summary = ': '.join((job_state.verb.upper(), location))


### PR DESCRIPTION
When displaying urls in certain terminals, the ending bracket of the url string place holder is incorporated into the final url.

**eg:** https://github.com/thp/urlwatch)

This merge has put a single space at the beginning and end of the url place holder, so now the end bracket will no longer become part of the url.