### PR TITLE
SendmailMailer: Specify recipient on the command line (Fixes #376)

### DIFF
--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -105,7 +105,7 @@ class SendmailMailer(Mailer):
         self.sendmail_path = sendmail_path
 
     def send(self, msg):
-        p = subprocess.Popen([self.sendmail_path, '-t', '-oi'],
+        p = subprocess.Popen([self.sendmail_path, '-oi', msg['To']],
                              stdin=subprocess.PIPE,
                              stderr=subprocess.PIPE,
                              universal_newlines=True)


### PR DESCRIPTION
Proposed fix for #376.