### PR TITLE
Use pypa recommended method for supplying scripts

### DIFF
--- a/lib/urlwatch/cli.py
+++ b/lib/urlwatch/cli.py
@@ -84,7 +84,7 @@ def setup_logger(verbose):
         root_logger.info('turning on verbose logging mode')
 
 
-if __name__ == '__main__':
+def main():
     config_file = os.path.join(urlwatch_dir, CONFIG_FILE)
     urls_file = os.path.join(urlwatch_dir, URLS_FILE)
     hooks_file = os.path.join(urlwatch_dir, HOOKS_FILE)
@@ -109,3 +109,7 @@ if __name__ == '__main__':
 
     # run urlwatcher
     urlwatch_command.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info < (3, 4):
     m['install_requires'].extend(['enum34'])
 if sys.platform == 'win32':
     m['install_requires'].extend(['colorama'])
-m['scripts'] = ['urlwatch']
+m['entry_points'] = {"console_scripts": ["urlwatch=urlwatch.cli:main"]}
 m['package_dir'] = {'': 'lib'}
 m['packages'] = ['urlwatch']
 m['python_requires'] = '>3.3.0'

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -79,7 +79,6 @@ def test_pep8_conformance():
     style = pycodestyle.StyleGuide(ignore=['E501', 'E402', 'W503'])
 
     py_files = [y for x in os.walk(os.path.abspath('.')) for y in glob(os.path.join(x[0], '*.py'))]
-    py_files.append(os.path.abspath('urlwatch'))
     result = style.check_files(py_files)
     assert result.total_errors == 0, "Found #{0} code style errors".format(result.total_errors)
 


### PR DESCRIPTION
See https://packaging.python.org/guides/distributing-packages-using-setuptools/#scripts

> Although setup() supports a scripts keyword for pointing to pre-made scripts to install, the recommended approach to achieve cross-platform compatibility is to use console_scripts entry points (see below).

Fixes #451 