### PR TITLE
Change slack to 40000 bytes

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -588,7 +588,7 @@ class TelegramReporter(TextReporter):
 
 class SlackReporter(TextReporter):
     """Custom Slack reporter"""
-    MAX_LENGTH = 4096
+    MAX_LENGTH = 40000
 
     __kind__ = 'slack'
 


### PR DESCRIPTION
Slack currently supports 40,000 characters, the 4096 was a suggested length that was much lower than supported.

https://api.slack.com/changelog/2018-04-truncating-really-long-messages