### PR TITLE
Provide hooks with content_type (raw from server) and mime_type

### DIFF
--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -75,7 +75,12 @@ class JobState(object):
         try:
             try:
                 self.load()
-                data, content_type = self.job.retrieve(self)
+                retrieved = self.job.retrieve(self)
+                try:
+                    data, content_type = retrieved
+                except ValueError:  # backward compatibility
+                    data = retrieved
+                    content_type = ''
                 if content_type:
                     self.job.content_type = content_type
                     self.job.mime_type = content_type.split(';')[0].strip()

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -75,7 +75,8 @@ class JobState(object):
         try:
             try:
                 self.load()
-                data = self.job.retrieve(self)
+                data, content_type = self.job.retrieve(self)
+                self.job.content_type = content_type
 
                 # Apply automatic filters first
                 data = FilterBase.auto_process(self, data)

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -76,7 +76,9 @@ class JobState(object):
             try:
                 self.load()
                 data, content_type = self.job.retrieve(self)
-                self.job.content_type = content_type
+                if content_type:
+                    self.job.content_type = content_type
+                    self.job.mime_type = content_type.split(';')[0].strip()
 
                 # Apply automatic filters first
                 data = FilterBase.auto_process(self, data)

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -289,7 +289,9 @@ class UrlJob(Job):
         # urlwatch behavior and try UTF-8 decoding first.
         content_type = response.headers.get('Content-type', '')
         content_type_match = self.CHARSET_RE.match(content_type)
-        if not content_type_match and not self.encoding:
+        result = None
+
+        def try_decoding(response):
             try:
                 try:
                     try:
@@ -301,10 +303,14 @@ class UrlJob(Job):
             except LookupError:
                 # If this is an invalid encoding, decode as ascii (Debian bug 731931)
                 return response.content.decode('ascii', 'ignore')
+
+        if not content_type_match and not self.encoding:
+            result = try_decoding(response)
+        else:
+            result = response.text
         if self.encoding:
             response.encoding = self.encoding
-
-        return response.text
+        return result
 
     def add_custom_headers(self, headers):
         """

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -209,7 +209,7 @@ class UrlJob(Job):
     __required__ = ('url',)
     __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
                     'headers', 'ignore_connection_errors', 'ignore_http_error_codes', 'encoding', 'timeout',
-                    'ignore_timeout_errors', 'ignore_too_many_redirects')
+                    'ignore_timeout_errors', 'ignore_too_many_redirects', 'content_type', 'mime_type')
 
     LOCATION_IS_URL = True
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -198,7 +198,7 @@ class ShellJob(Job):
         if result != 0:
             raise ShellError(result)
 
-        return stdout_data.decode('utf-8')
+        return (stdout_data.decode('utf-8'), 'text/plain')
 
 
 class UrlJob(Job):
@@ -254,7 +254,7 @@ class UrlJob(Job):
         file_scheme = 'file://'
         if self.url.startswith(file_scheme):
             logger.info('Using local filesystem (%s URI scheme)', file_scheme)
-            return open(self.url[len(file_scheme):], 'rt').read()
+            return (open(self.url[len(file_scheme):], 'rt').read(), 'text/plain')
 
         if self.headers:
             self.add_custom_headers(headers)
@@ -310,7 +310,7 @@ class UrlJob(Job):
             result = response.text
         if self.encoding:
             response.encoding = self.encoding
-        return result
+        return (result, content_type)
 
     def add_custom_headers(self, headers):
         """
@@ -364,4 +364,4 @@ class BrowserJob(Job):
         from requests_html import HTMLSession
         session = HTMLSession()
         response = session.get(self.navigate)
-        return response.html.html
+        return (response.html.html, response.headers.get('Content-type', ''))

--- a/share/urlwatch/examples/hooks.py.example
+++ b/share/urlwatch/examples/hooks.py.example
@@ -41,7 +41,10 @@ from urlwatch import reporters
 #    __required__ = ('username', 'password')
 #
 #    def retrieve(self, job_state):
-#        return 'Would log in to {} with {} and {}\n'.format(self.url, self.username, self.password)
+#        return (
+#            'Would log in to {} with {} and {}\n'.format(self.url, self.username, self.password),
+#            'text/plain',
+#        )
 
 
 #class CaseFilter(filters.FilterBase):


### PR DESCRIPTION
This allows creating automatic converters like:
```
class AtomFeedFilter(AutoMatchFilter):           
    MATCH = {'mime_type': 'application/atom+xml'}
    def filter(self, data):
        ...
```