### PR TITLE
Create requirements file for easier installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pyyaml
+minidb
+requests
+keyring
+appdirs
+lxml
+cssselect


### PR DESCRIPTION
I added a `requirements.txt` file so the dependencies can be installed simply with: `pip install -r requirements.txt`