### PR TITLE
Remove pycodestyle hard dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
   - "3.7"
   - "3.8"
 install:
-  - python setup.py install_dependencies
+  - pip install -r requirements.txt
+  - pip install pycodestyle
 script: nosetests -v

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
-from distutils import cmd
 
 import os
 import re
@@ -35,33 +34,6 @@ m['project_urls'] = {
     'Source': 'https://github.com/thp/urlwatch',
     'Tracker': 'https://github.com/thp/urlwatch/issues',
 }
-
-
-class InstallDependencies(cmd.Command):
-    """Install dependencies only"""
-
-    description = 'Only install required packages using pip'
-    user_options = []
-
-    def initialize_options(self):
-        ...
-
-    def finalize_options(self):
-        ...
-
-    def run(self):
-        global m
-        try:
-            from pip._internal import main
-        except ImportError:
-            from pip import main
-        try:
-            main(['install', '--upgrade'] + m['install_requires'])
-        except TypeError:  # recent pip
-            main.main(['install', '--upgrade'] + m['install_requires'])
-
-
-m['cmdclass'] = {'install_dependencies': InstallDependencies}
 
 del m['copyright']
 setup(**m)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.version_info < (3, 3):
 m['name'] = 'urlwatch'
 m['author'], m['author_email'] = re.match(r'(.*) <(.*)>', m['author']).groups()
 m['description'], m['long_description'] = docs[0].strip().split('\n\n', 1)
-m['install_requires'] = ['minidb', 'PyYAML', 'requests', 'keyring', 'pycodestyle', 'appdirs', 'lxml', 'cssselect']
+m['install_requires'] = ['minidb', 'PyYAML', 'requests', 'keyring', 'appdirs', 'lxml', 'cssselect']
 if sys.platform == 'win32':
     m['install_requires'].extend(['colorama'])
 m['entry_points'] = {"console_scripts": ["urlwatch=urlwatch.cli:main"]}


### PR DESCRIPTION
pycodestyle is only used during testing, but after the switch to entry
points, urlwatch will not run without it.

For reference: https://bugs.archlinux.org/task/66532

Since you've added a requirements.txt and Travis uses that by default,
may as well use that in .travis.yml.