### PR TITLE
Docs: rewrote Jobs page and added an Introduction page

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -1,10 +1,12 @@
+.. _advanced_topics:
+
 Advanced Topics
 ===============
 
 If you want to change some settings for all your jobs, edit the
 ``job_defaults`` section in your config file:
 
-.. code:: yaml
+.. code-block:: yaml
 
    ...
    job_defaults:
@@ -25,7 +27,6 @@ Quickly adding new URLs to the job list from the command line::
     urlwatch --add url=http://example.org,name=Example
 
 
-
 Using word-based differences
 ----------------------------
 
@@ -34,7 +35,7 @@ two filenames (old, new) as parameter and returns on its standard output
 the difference of the files), for example to use GNU ``wdiff`` to get
 word-based differences instead of line-based difference:
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: https://example.com/
    diff_tool: wdiff
@@ -50,11 +51,11 @@ Ignoring connection errors
 
 In some cases, it might be useful to ignore (temporary) network errors
 to avoid notifications being sent. While there is a ``display.error``
-config option (defaulting to ``True``) to control reporting of errors
+config option (defaulting to ``true``) to control reporting of errors
 globally, to ignore network errors for specific jobs only, you can use
 the ``ignore_connection_errors`` key in the job list configuration file:
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: https://example.com/
    ignore_connection_errors: true
@@ -62,14 +63,14 @@ the ``ignore_connection_errors`` key in the job list configuration file:
 Similarly, you might want to ignore some (temporary) HTTP errors on the
 server side:
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: https://example.com/
    ignore_http_error_codes: 408, 429, 500, 502, 503, 504
 
 or ignore all HTTP errors if you like:
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: https://example.com/
    ignore_http_error_codes: 4xx, 5xx
@@ -82,7 +83,7 @@ For web pages with misconfigured HTTP headers or rare encodings, it may
 be useful to explicitly specify an encoding from Python’s `Standard
 Encodings <https://docs.python.org/3/library/codecs.html#standard-encodings>`__.
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: https://example.com/
    encoding: utf-8
@@ -95,7 +96,7 @@ By default, url jobs timeout after 60 seconds. If you want a different
 timeout period, use the ``timeout`` key to specify it in number of
 seconds, or set it to 0 to never timeout.
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: https://example.com/
    timeout: 300
@@ -107,7 +108,7 @@ Supplying cookie data
 It is possible to add cookies to HTTP requests for pages that need it,
 the YAML syntax for this is:
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: http://example.com/
    cookies:
@@ -122,7 +123,7 @@ If a webpage frequently changes between several known stable states, it
 may be desirable to have changes reported only if the webpage changes
 into a new unknown state. You can use ``compared_versions`` to do this.
 
-.. code:: yaml
+.. code-block:: yaml
 
    url: https://example.com/
    compared_versions: 3
@@ -130,3 +131,18 @@ into a new unknown state. You can use ``compared_versions`` to do this.
 In this example, changes are only reported if the webpage becomes
 different from the latest three distinct states. The differences are
 shown relative to the closest match.
+
+
+Receving a report every time urlwatch runs
+------------------------------------------
+If you are watching pages that change seldomly, but you still want to
+be notified daily if ``urlwatch`` still works, you can watch the output
+of the ``date`` command, for example:
+
+.. code-block:: yaml
+
+   name: "urlwatch watchdog"
+   command: "date"
+
+Since the output of ``date`` changes every second, this job should produce a
+report every time urlwatch is run.

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -1,3 +1,5 @@
+.. _dependencies:
+
 Dependencies
 ============
 
@@ -21,9 +23,7 @@ The dependencies can be installed with (add ``--user`` to install to ``$HOME``):
 
 ::
 
-    python3 -m pip install \
-        pyyaml minidb requests \
-        keyring appdirs lxml cssselect
+    python3 -m pip install pyyaml minidb requests keyring appdirs lxml cssselect
 
 
 Optional Packages

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -1,3 +1,5 @@
+.. _filters:
+
 Filters
 =======
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,5 @@
 .. highlight:: none
+
 ::
 
                             _               _       _       ____
@@ -55,6 +56,7 @@ The Handbook
 .. toctree::
    :maxdepth: 2
 
+   introduction
    dependencies
    jobs
    filters

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -1,0 +1,79 @@
+.. _introduction:
+
+Introduction
+============
+
+`urlwatch` monitors the output of webpages or arbitrary shell commands.
+
+Every time you run `urlwatch`, it:
+
+- retrieves the outpout and processes it
+- compares it with the version retrieved the previous time ("diffing")
+- if it finds any differences, generates a summary "report" that can be displayed or sent via one or more methods, such as email
+
+:ref:`Jobs`
+-----------
+Each website or shell command to be monitored consitute a "job".
+
+The instructions for each such job are contained in a config file in the `YAML format <https://yaml.org/spec/>`__, accessible with the ``urlwatch --edit`` command (if you get an error, define an editor such as with ``$ export EDITOR=/bin/nano``).
+
+Typically, the first entry ("key") in a job is a ``name``, which can be anything you want and helps you identify what you're monitoring.
+
+The second key is one of either ``url``, ``navigate`` or ``command``:
+
+- ``url`` retrieves what is served by the web server,
+- ``navigate`` handles more web pages requiring JavaScript to display the content to be monitored, and
+- ``command`` runs a shell command. 
+
+You can then use optional keys to finely control various job's parameters.
+
+Finally, you often use the ``filter`` key to select one or more :ref:`filters` to apply to the data after it is retrieved, to:
+
+- select HTML: ``css``, ``xpath``, ``element-by-class``, ``element-by-id``, ``element-by-style``, ``element-by-tag``
+- make HTML more readable: ``html2text``, ``beautify``
+- make PDFs readable: ``pdf2text``
+- make JSON more readable: ``format-json``
+- make iCal more readable: ``ical2text``
+- make binary readable: ``hexdump``
+- just detect changes: ``sha1sum``
+- edit text: ``grep``, ``grepi``, ``strip``, ``sort``
+
+These :ref:`filters` can be chained. As an example, after retrieving an HTML document by using the ``url`` key, you can extract a selection with the ``xpath`` filter, convert this to text with ``html2text``, use ``grep`` to extract only lines matching a specific regular expression, and then ``sort`` them:
+
+.. code-block:: yaml
+
+    name: "Sample urlwatch job definition"
+    url: "https://example.dummy/"
+    https_proxy: "http://dummy.proxy/"
+    max_tries: 2
+    filter:
+      - xpath: '//section[@role="main"]'
+      - html2text:
+          method: pyhtml2text
+          unicode_snob: true
+          body_width: 0
+          inline_links: false
+          ignore_links: true
+          ignore_images: true
+          pad_tables: false
+          single_line_break: true
+      - grep: "lines I care about"
+      - sort:
+    ---
+
+If you have more than one job, per `YAML specifications <https://yaml.org/spec/>`__, you separate them with a line containing only ``---``.
+
+:ref:`Reporters`
+----------------
+`urlwatch` can be configured to do something with its report besides (or in addition to) the default of displaying it on the console, such as one or more of:
+
+- ``email`` (using SMPT)
+- email using ``mailgun``
+- ``slack``
+- ``pushbullet``
+- ``telegram``
+- ``matrix``
+- ``pushover``
+- ``stdout``
+
+This configuration is contained in its own YAML file accessible with ``urlwatch --edit-config`` and documented at :ref:`Reporters`.

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -1,117 +1,119 @@
+.. _jobs:
+
 Jobs
 ====
 
-Jobs are the kind of things that urlwatch can monitor. The most-used
-job type is ``url`` for watching web pages without dynamic HTML.
+Jobs are the kind of things that `urlwatch` can monitor. 
 
-Optional keys for all jobs:
+The list of jobs to run are contained in the configuration file ``urls.yaml``,
+accessed with the command ``urlwatch --edit``, each separated by a line
+containing only ``---``.
 
-- ``kind``: Either ``url``, ``shell`` or ``browser``; for the built-in
-  jobs, this is usually auto-detected and can be left out, because the
-  job kind can be derived from the unique key (``url``, ``command`` or
-  ``navigate``) that the job has
-- ``name``: Human-readable name/label of the job
-- ``filter``: Which filters (if any) to apply to the output
-- ``max_tries``: How often to retry fetching the resource
-- ``diff_tool``: Custom tool for generating diff text
-- ``compared_versions``: Number of versions to compare for similarity
+While optional, it is recommended that each job starts with a ``name`` entry:
 
-The configuration file ``urls.yaml`` contains a list of jobs to run.
+.. code-block:: yaml
+
+    name: "This is a human-readable name/label of the job"
 
 
 URL
 ---
 
-This is the main job type -- it retrieves a document from a web server::
+This is the main job type -- it retrieves a document from a web server:
 
-    kind: url
-    name: "urlwatch webpage"
+.. code-block:: yaml
+
+    name: "urlwatch homepage"
     url: "https://thp.io/2008/urlwatch/"
 
 Required keys:
 
 - ``url``: The URL to the document to watch for changes
 
-Optional keys:
+Job-specific optional keys:
 
-- ``cookies``: Cookies to send with the request
-- ``data``: HTTP POST/PUT data
+- ``cookies``: Cookies to send with the request (see :ref:`advanced_topics`)
 - ``method``: HTTP method to use (default: ``GET``)
-- ``ssl_no_verify``: Do not verify SSL certificates
-- ``ignore_cached``: Do not use cache control (ETag/Last-Modified) values
+- ``data``: HTTP POST/PUT data
+- ``ssl_no_verify``: Do not verify SSL certificates (true/false)
+- ``ignore_cached``: Do not use cache control (ETag/Last-Modified) values (true/false)
 - ``http_proxy``: Proxy server to use for HTTP requests
 - ``https_proxy``: Proxy server to use for HTTPS requests
 - ``headers``: HTTP header to send along with the request
-- ``encoding``: Override the character encoding from the server
-- ``timeout``: Override the default socket timeout
-- ``ignore_connection_errors``: Ignore (temporary) connection errors
-- ``ignore_http_error_codes``: List of HTTP errors to ignore
+- ``encoding``: Override the character encoding from the server (see :ref:`advanced_topics`)
+- ``timeout``: Override the default socket timeout (see :ref:`advanced_topics`)
+- ``ignore_connection_errors``: Ignore (temporary) connection errors (see :ref:`advanced_topics`)
+- ``ignore_http_error_codes``: List of HTTP errors to ignore (see :ref:`advanced_topics`)
 - ``ignore_timeout_errors``: Do not report errors when the timeout is hit
-- ``ignore_too_many_redirects``: Ignore redirect loops
+- ``ignore_too_many_redirects``: Ignore redirect loops (see :ref:`advanced_topics`)
+
+(Note: ``url`` implies ``kind: url``)
 
 
-Shell
------
+Navigate
+--------
 
-This job allows you to watch the output of arbitrary shell commands,
-which is useful for e.g. monitoring a FTP uploader folder, output of
-scripts that query external devices (RPi GPIO), etc...
+This job type is a resource-intensive variant of "URL" to handle web pages
+requiring JavaScript in order to render the content to be monitored.
 
-Required keys:
+The optional ``requests-html`` package must be installed to run "Navigate" jobs
+(see :ref:`dependencies`).
 
-- ``command``: The shell command to execute
+.. code-block:: yaml
 
-Here is a simple example job:
-
-.. code:: yaml
-
-   kind: shell
-   name: "What is in my Home Directory?"
-   command: "ls -al ~"
-
-If you are watching pages that change seldomly, but you still want to
-be notified daily if ``urlwatch`` still works, you can watch the output
-of the ``date`` command, for example:
-
-.. code:: yaml
-
-   kind: shell
-   name: "Daily urlwatch watchdog"
-   command: "date +%F"
-
-Since the output of ``date +%F`` (YYYY-MM-DD) changes every day, this
-job should produce a diff / report every day.
-
-
-Browser
--------
-
-This is an advanced variant of the "URL" job and uses a headless
-web browser instance to run client-side JavaScript and handle more
-dynamic web pages.
+   name: "A page with JavaScript"
+   navigate: "https://example.org/"
 
 Required keys:
 
 - ``navigate``: URL to navigate to with the browser
 
-If the webpage you are trying to watch runs client-side JavaScript to
-render the page, `Requests-HTML <http://html.python-requests.org>`__ can
-now be used to render the page in a headless Chromium instance first and
-then use the HTML of the resulting page.
+Job-specific optional keys:
 
-Use the ``browser`` kind in the configuration and the ``navigate`` key
-to set the URL to retrieve. note that the normal ``url`` job keys are
-not supported for the ``browser`` job types at the moment, for example:
+- none
 
-.. code:: yaml
+As this job uses `Requests-HTML <http://html.python-requests.org>`__
+to render the page in a headless Chromium instance, it requires massively
+more resources than a "URL" job. Use it only on pages where ``url`` does not
+give the right results.
 
-   kind: browser
-   name: "A Page With JavaScript"
-   navigate: http://example.org/
+Hint: in many instances instead of using "Navigate" you can 
+monitor the output of an API called by the site during page loading
+containing the information you're after using the much faster "URL" job type.
 
-The "browser" job does not support all the custom options that the "url"
-job supports. Also, it requires more resources (it starts up a whole
-headless browser instance), so only use it on pages where the "url" job
-does not give the right results. For some pages, instead of watching the
-"frontend" HTML page, watching a JSON URL from the API backend can do
-the trick without having to resort to running client-side JavaScript.
+(Note: ``navigate`` implies ``kind: browser``)
+
+
+Command
+-------
+
+This job type allows you to watch the output of arbitrary shell commands,
+which is useful for e.g. monitoring a FTP uploader folder, output of
+scripts that query external devices (RPi GPIO), etc...
+
+.. code-block:: yaml
+
+   name: "What is in my Home Directory?"
+   command: "ls -al ~"
+
+Required keys:
+
+- ``command``: The shell command to execute
+
+Job-specific optional keys:
+
+- none
+
+(Note: ``command`` implies ``kind: shell``)
+
+
+Optional keys for all job types
+-------------------------------
+
+- ``name``: Human-readable name/label of the job
+- ``filter``: :ref:`filters` (if any) to apply to the output
+- ``max_tries``: Number of times to retry fetching the resource
+- ``diff_tool``: Command to a custom tool for generating diff text
+- ``compared_versions``: Number of versions to compare for similarity
+- ``kind`` (redundant): Either ``url``, ``shell`` or ``browser``.  Automatically derived from the unique key (``url``, ``command`` or ``navigate``) of the job type
+

--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -1,3 +1,5 @@
+.. _reporters:
+
 Reporters
 =========
 


### PR DESCRIPTION
Did a fair amount of cleanup to a small part of the documentation (the Jobs page) and started an Introduction page.  

Of note is the deprecation of the `kind` key, which was extremely confusing to this new user and has been made redundant (per [current documentation](https://urlwatch.readthedocs.io/en/latest/jobs.html): "`kind` [...] is usually auto-detected and can be left out, because the job kind can be derived from the unique key)" and therefore unneeded.

Also moved from Jobs to Advanced Topics section the tip about "If you are watching pages that change seldomly, but you still want to be notified daily if urlwatch still works, you can watch the output of the date command" 

Finally, added reST labels to allow cross-referencing where needed (more need to be added) and made opportunistic fixes such as using standard reStructuredText directive for yaml [code-blocks](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block).