### PR TITLE
Have html2text filter using Python library return full ("absolute") URLs instead of relative ones

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -200,7 +200,8 @@ class Html2TextFilter(FilterBase):
             method = subfilter
             options = {}
         from .html2txt import html2text
-        return html2text(data, method=method, options=options)
+        return html2text(data, baseurl=getattr(self.job, 'url', getattr(self.job, 'navigate', '')),
+                         method=method, options=options)
 
 
 class Pdf2TextFilter(FilterBase):

--- a/lib/urlwatch/html2txt.py
+++ b/lib/urlwatch/html2txt.py
@@ -48,7 +48,7 @@ def html2text(data, baseurl, method, options):
                         options: https://linux.die.net/man/1/html2text
      'bs4'            - Use Beautiful Soup library to prettify the HTML
                         options: "parser" only, bs4 supports "lxml", "html5lib", and "html.parser"
-                        http://beautiful-soup-4.readthedocs.io/en/latest/#specifying-the-parser-to-use
+                        https://www.crummy.com/software/BeautifulSoup/bs4/doc/#specifying-the-parser-to-use
      're'             - A simple regex-based HTML tag stripper
      'pyhtml2text'    - Use Python module "html2text"
                         options: https://github.com/Alir3z4/html2text/blob/master/docs/usage.md#available-options

--- a/lib/urlwatch/html2txt.py
+++ b/lib/urlwatch/html2txt.py
@@ -36,7 +36,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def html2text(data, method, options):
+def html2text(data, baseurl, method, options):
     """
     Convert a string consisting of HTML to plain text
     for easy difference checking.
@@ -61,6 +61,7 @@ def html2text(data, method, options):
     if method == 'pyhtml2text':
         import html2text
         parser = html2text.HTML2Text()
+        parser.baseurl = baseurl
         for k, v in options.items():
             setattr(parser, k.lower(), v)
         d = parser.handle(data)


### PR DESCRIPTION
The `html2text` filter `method: pyhytml2text` (which uses the `html2text` python library ) will now return full ("absolute") URLs instead of relative ones.

The implementation is scalable:

1. `handler.JobState.process` extracts the URL as `baseurl` and passes it to `filters.FilterBase.process`
2. `filters.FilterBase.process` passes it on to the `filtercls` classes, so all filters have access to it
3. The filter `html2text` passes it to `html2txt.html2text`
4. `html2txt.html2text`, when calling the `html2text` Python library, now sets the library's `baseurl` option so it can correctly parse relative URLs

Benefit: links that previously read e.g. `../../index.html` now read  e.g. `https://www.example.com/index.html`