### PR TITLE
Removed cssselect (replaced by lxml.cssselect)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-pyyaml
-minidb
-requests
-keyring
 appdirs
+keyring
 lxml
-cssselect
+minidb
+pyyaml
+requests


### PR DESCRIPTION
Removed the requirement to install the library cssselect, which is never imported.

Currently only importing 
```python
from lxml.cssselect import CSSSelector
```
in `filters.py`