### PR TITLE
Fixed most flake8 errors

### DIFF
--- a/lib/urlwatch/ical2txt.py
+++ b/lib/urlwatch/ical2txt.py
@@ -36,7 +36,7 @@ def ical2text(ical_string):
     else:
         try:
             parsedCal = vobject.readOne(ical_string)
-        except Exception as e:
+        except Exception:
             parsedCal = vobject.readOne(ical_string.decode('utf-8', 'ignore'))
 
     for event in parsedCal.getChildren():

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -93,7 +93,8 @@ class SMTPMailer(Mailer):
             elif keyring is not None:
                 passwd = keyring.get_password(self.smtp_server, self.smtp_user)
                 if passwd is None:
-                    raise ValueError('No password available in keyring for {}, {}'.format(self.smtp_server, self.smtp_user))
+                    raise ValueError('No password available in keyring for {}, {}'
+                                     .format(self.smtp_server, self.smtp_user))
             s.login(self.smtp_user, passwd)
 
         s.sendmail(msg['From'], msg['To'].split(','), msg.as_string())

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -451,7 +451,7 @@ class WebServiceReporter(TextReporter):
 
         try:
             service = self.web_service_get()
-        except Exception as e:
+        except Exception:
             logger.error('Failed to load or connect to %s - are the dependencies installed and configured?',
                          self.__kind__, exc_info=True)
             return

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -320,7 +320,8 @@ class UrlsYaml(BaseYamlFileStorage, UrlsBaseFileStorage):
         filename = args[0]
         if filename is not None and os.path.exists(filename):
             with open(filename) as fp:
-                return [JobBase.unserialize(job) for job in yaml.load_all(fp, Loader=yaml.SafeLoader) if job is not None]
+                return [JobBase.unserialize(job) for job in yaml.load_all(fp, Loader=yaml.SafeLoader)
+                        if job is not None]
 
     def save(self, *args):
         jobs = args[0]
@@ -463,8 +464,11 @@ class CacheMiniDBStorage(CacheStorage):
         return (guid for guid, in CacheEntry.query(self.db, minidb.Function('distinct', CacheEntry.c.guid)))
 
     def load(self, job, guid):
-        for data, timestamp, tries, etag in CacheEntry.query(self.db, CacheEntry.c.data // CacheEntry.c.timestamp // CacheEntry.c.tries // CacheEntry.c.etag,
-                                                             order_by=minidb.columns(CacheEntry.c.timestamp.desc, CacheEntry.c.tries.desc),
+        for data, timestamp, tries, etag in CacheEntry.query(self.db,
+                                                             CacheEntry.c.data // CacheEntry.c.timestamp
+                                                             // CacheEntry.c.tries // CacheEntry.c.etag,
+                                                             order_by=minidb.columns(CacheEntry.c.timestamp.desc,
+                                                                                     CacheEntry.c.tries.desc),
                                                              where=CacheEntry.c.guid == guid, limit=1):
             return data, timestamp, tries, etag
 
@@ -475,9 +479,10 @@ class CacheMiniDBStorage(CacheStorage):
         if count < 1:
             return history
         for data, timestamp in CacheEntry.query(self.db, CacheEntry.c.data // CacheEntry.c.timestamp,
-                                                order_by=minidb.columns(CacheEntry.c.timestamp.desc, CacheEntry.c.tries.desc),
+                                                order_by=minidb.columns(CacheEntry.c.timestamp.desc,
+                                                                        CacheEntry.c.tries.desc),
                                                 where=(CacheEntry.c.guid == guid)
-                                                & ((CacheEntry.c.tries == 0) | (CacheEntry.c.tries == None))):  # noqa
+                                                & ((CacheEntry.c.tries == 0) | (CacheEntry.c.tries == None))):  # noqa:E711
             if data not in history:
                 history[data] = timestamp
                 if len(history) >= count:

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -32,8 +32,6 @@ import concurrent.futures
 import logging
 import difflib
 
-import requests
-
 from .handler import JobState
 from .jobs import NotModifiedError
 


### PR DESCRIPTION
Fixed the following flake8 errors:
```ical2txt.py:39:9: F841 local variable 'e' is assigned to but never used
mailer.py:96:121: E501 line too long (124 > 120 characters)
reporters.py:454:9: F841 local variable 'e' is assigned to but never used
storage.py:323:121: E501 line too long (121 > 120 characters)
storage.py:466:121: E501 line too long (157 > 120 characters)
storage.py:467:121: E501 line too long (139 > 120 characters)
storage.py:478:121: E501 line too long (126 > 120 characters)
worker.py:35:1: F401 'requests' imported but unused
```

Left the following flake8 error, which for some reason was `#  noqa`'d out (just restricted the noqa to the pre-existing error): `storage.py:485:100: E711 comparison to None should be 'if cond is None:'`.
It appears that `CacheEntry.c.tries == None` should be written as `CacheEntry.c.tries is None` but am not sure what's going on in that huge logic statement.