### PR TITLE
Add a redis cache backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - Project URLs added to `setup.py`
 - Sphinx-based documentation
+- Support for a Redis cache backend via `--cache=redis://localhost:6379/`
 
 ### Fixed
 

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -146,3 +146,13 @@ of the ``date`` command, for example:
 
 Since the output of ``date`` changes every second, this job should produce a
 report every time urlwatch is run.
+
+
+Using Redis as a cache backend
+------------------------------------------
+If you want to use Redis as a cache backend over the default SQLite3 file::
+
+    urlwatch --cache=redis://localhost:6379/
+    
+There is no migration path from the SQLite3 format, the cache will be empty
+the first time Redis is used.0

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -153,6 +153,6 @@ Using Redis as a cache backend
 If you want to use Redis as a cache backend over the default SQLite3 file::
 
     urlwatch --cache=redis://localhost:6379/
-    
+
 There is no migration path from the SQLite3 format, the cache will be empty
-the first time Redis is used.0
+the first time Redis is used.

--- a/lib/urlwatch/cli.py
+++ b/lib/urlwatch/cli.py
@@ -101,7 +101,7 @@ def main():
     # setup storage API
     config_storage = YamlConfigStorage(command_config.config)
 
-    if command_config.cache.startswith('redis://') or command_config.cache.startswith('rediss://'):
+    if any(command_config.cache.startswith(prefix) for prefix in ('redis://', 'rediss://')):
         cache_storage = CacheRedisStorage(command_config.cache)
     else:
         cache_storage = CacheMiniDBStorage(command_config.cache)

--- a/lib/urlwatch/cli.py
+++ b/lib/urlwatch/cli.py
@@ -54,7 +54,7 @@ if bindir != 'bin':
 from urlwatch.command import UrlwatchCommand
 from urlwatch.config import CommandConfig
 from urlwatch.main import Urlwatch
-from urlwatch.storage import YamlConfigStorage, CacheMiniDBStorage, UrlsYaml
+from urlwatch.storage import YamlConfigStorage, CacheMiniDBStorage, CacheRedisStorage, UrlsYaml
 
 # One minute (=60 seconds) timeout for each request to avoid hanging
 socket.setdefaulttimeout(60)
@@ -100,7 +100,13 @@ def main():
 
     # setup storage API
     config_storage = YamlConfigStorage(command_config.config)
-    cache_storage = CacheMiniDBStorage(command_config.cache)
+    alternative_cache = config_storage.config['storage']['cache']['redis']
+
+    if alternative_cache:
+        cache_storage = CacheRedisStorage(alternative_cache)
+    else:
+        cache_storage = CacheMiniDBStorage(command_config.cache)
+
     urls_storage = UrlsYaml(command_config.urls)
 
     # setup urlwatcher

--- a/lib/urlwatch/cli.py
+++ b/lib/urlwatch/cli.py
@@ -100,10 +100,9 @@ def main():
 
     # setup storage API
     config_storage = YamlConfigStorage(command_config.config)
-    alternative_cache = config_storage.config['storage']['cache']['redis']
 
-    if alternative_cache:
-        cache_storage = CacheRedisStorage(alternative_cache)
+    if command_config.cache.startswith('redis://') or command_config.cache.startswith('rediss://'):
+        cache_storage = CacheRedisStorage(command_config.cache)
     else:
         cache_storage = CacheMiniDBStorage(command_config.cache)
 

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -84,7 +84,7 @@ class CommandConfig(BaseConfig):
                            default=self.config)
         group.add_argument('--hooks', metavar='FILE', help='use FILE as hooks.py module',
                            default=self.hooks)
-        group.add_argument('--cache', metavar='FILE', help='use FILE as cache database, alternatives can accept a redis path',
+        group.add_argument('--cache', metavar='FILE', help='use FILE as cache database, alternatively can accept a redis path',
                            default=self.cache)
 
         group = parser.add_argument_group('Authentication')

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -84,7 +84,7 @@ class CommandConfig(BaseConfig):
                            default=self.config)
         group.add_argument('--hooks', metavar='FILE', help='use FILE as hooks.py module',
                            default=self.hooks)
-        group.add_argument('--cache', metavar='FILE', help='use FILE as cache database, alternatively can accept a redis path',
+        group.add_argument('--cache', metavar='FILE', help='use FILE as cache database, alternatively can accept a redis URI',
                            default=self.cache)
 
         group = parser.add_argument_group('Authentication')

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -84,7 +84,7 @@ class CommandConfig(BaseConfig):
                            default=self.config)
         group.add_argument('--hooks', metavar='FILE', help='use FILE as hooks.py module',
                            default=self.hooks)
-        group.add_argument('--cache', metavar='FILE', help='use FILE as cache database',
+        group.add_argument('--cache', metavar='FILE', help='use FILE as cache database, alternatives can accept a redis path',
                            default=self.cache)
 
         group = parser.add_argument_group('Authentication')

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -61,12 +61,6 @@ DEFAULT_CONFIG = {
         'unchanged': False,
     },
 
-    'storage': {
-        'cache': {
-            'redis': False,
-        },
-    },
-
     'report': {
         'text': {
             'line_length': 75,

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -39,6 +39,16 @@ import yaml
 import minidb
 import logging
 
+try:
+    import msgpack
+except ImportError:
+    msgpack = None
+
+try:
+    import redis
+except ImportError:
+    redis = None
+
 from .util import atomic_rename, edit_file
 from .jobs import JobBase, UrlJob, ShellJob
 
@@ -49,6 +59,12 @@ DEFAULT_CONFIG = {
         'new': True,
         'error': True,
         'unchanged': False,
+    },
+
+    'storage': {
+        'cache': {
+            'redis': False,
+        },
     },
 
     'report': {
@@ -505,5 +521,74 @@ class CacheMiniDBStorage(CacheStorage):
             result = CacheEntry.delete_where(self.db, (CacheEntry.c.guid == guid) & (CacheEntry.c.id != keep_id))
             self.db.commit()
             return result
+
+        return 0
+
+
+class CacheRedisStorage(CacheStorage):
+    def __init__(self, filename):
+        super().__init__(filename)
+
+        if redis is None or msgpack is None:
+            raise ImportError('redis + msgpack are missing')
+
+        self.db = redis.from_url(filename)
+
+    def _make_key(self, guid):
+        return 'guid:' + guid
+
+    def close(self):
+        self.db.connection_pool.disconnect()
+        self.db = None
+
+    def get_guids(self):
+        guids = []
+        for guid in self.db.keys(b'guid:*'):
+            guids.append(str(guid[len('guid:'):]))
+        return guids
+
+    def load(self, job, guid):
+        key = self._make_key(guid)
+        data = self.db.lindex(key, 0)
+
+        if data:
+            r = msgpack.unpackb(data)
+            return r['data'], r['timestamp'], r['tries'], r['etag']
+
+        return None, None, 0, None
+
+    def get_history_data(self, guid, count=1):
+        history = {}
+        if count < 1:
+            return history
+
+        key = self._make_key(guid)
+        for i in range(0, self.db.llen(key)):
+            r = self.db.lindex(key, i)
+            c = msgpack.unpackb(r)
+            if (c['tries'] == 0 or c['tries'] is None):
+                if c['data'] not in history:
+                    history[c['data']] = c['timestamp']
+                    if len(history) >= count:
+                        break
+        return history
+
+    def save(self, job, guid, data, timestamp, tries, etag=None):
+        r = {
+            'data': data,
+            'timestamp': timestamp,
+            'tries': tries,
+            'etag': etag,
+        }
+        self.db.lpush(self._make_key(guid), msgpack.packb(r, use_bin_type=True))
+
+    def delete(self, guid):
+        self.db.delete(self._make_key(guid))
+
+    def clean(self, guid):
+        key = self._make_key(guid)
+        i = self.db.llen(key)
+        if self.db.ltrim(key, 0, 0):
+            return i - self.db.llen(key)
 
         return 0


### PR DESCRIPTION
I'm wanting to run multiple workers on different machines and also do some monitoring of changes. This allows the cache to live off box if needed.

The redis list type maps well to the cache as we only ever push new history snapshots and read from the beginning.

I saw @liewegas had written a postgres version in a fork so might be more than just me after this.

Also not sure how much further to take this, I could make the yaml bit a litlte more generic and throw together a MySQL one.