### PR TITLE
Reorganize migration code

### DIFF
--- a/lib/urlwatch/cli.py
+++ b/lib/urlwatch/cli.py
@@ -53,6 +53,7 @@ if bindir != 'bin':
 from urlwatch.command import UrlwatchCommand
 from urlwatch.config import CommandConfig
 from urlwatch.main import Urlwatch
+from urlwatch.migration import migrate_cache, migrate_urls
 
 # Ignore SIGPIPE for stdout (see https://github.com/thp/urlwatch/issues/77)
 try:
@@ -92,6 +93,10 @@ def main():
     command_config = CommandConfig(pkgname, urlwatch_dir, bindir, prefix,
                                    config_file, urls_file, hooks_file, cache_file, False)
     setup_logger(command_config.verbose)
+
+    # migration
+    migrate_urls(command_config)
+    migrate_cache(command_config)
 
     # setup urlwatcher
     urlwatch = Urlwatch(command_config)

--- a/lib/urlwatch/cli.py
+++ b/lib/urlwatch/cli.py
@@ -53,7 +53,6 @@ if bindir != 'bin':
 from urlwatch.command import UrlwatchCommand
 from urlwatch.config import CommandConfig
 from urlwatch.main import Urlwatch
-from urlwatch.storage import YamlConfigStorage, CacheMiniDBStorage, CacheRedisStorage, UrlsYaml
 
 # Ignore SIGPIPE for stdout (see https://github.com/thp/urlwatch/issues/77)
 try:
@@ -94,18 +93,8 @@ def main():
                                    config_file, urls_file, hooks_file, cache_file, False)
     setup_logger(command_config.verbose)
 
-    # setup storage API
-    config_storage = YamlConfigStorage(command_config.config)
-
-    if any(command_config.cache.startswith(prefix) for prefix in ('redis://', 'rediss://')):
-        cache_storage = CacheRedisStorage(command_config.cache)
-    else:
-        cache_storage = CacheMiniDBStorage(command_config.cache)
-
-    urls_storage = UrlsYaml(command_config.urls)
-
     # setup urlwatcher
-    urlwatch = Urlwatch(command_config, config_storage, cache_storage, urls_storage)
+    urlwatch = Urlwatch(command_config)
     urlwatch_command = UrlwatchCommand(urlwatch)
 
     # run urlwatcher

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -33,7 +33,6 @@ import logging
 import os
 
 import urlwatch
-from .migration import migrate_cache, migrate_urls
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +55,6 @@ class CommandConfig(BaseConfig):
         super().__init__(pkgname, urlwatch_dir, config, urls, cache, hooks, verbose)
         self.bindir = bindir
         self.prefix = prefix
-        self.migrate_cache = migrate_cache
-        self.migrate_urls = migrate_urls
 
         if self.bindir == 'bin':
             # Installed system-wide

--- a/lib/urlwatch/main.py
+++ b/lib/urlwatch/main.py
@@ -63,17 +63,11 @@ class Urlwatch(object):
 
         self.check_directories()
 
-        if hasattr(self.urlwatch_config, 'migrate_urls'):
-            self.urlwatch_config.migrate_urls(self)
-
         if not self.urlwatch_config.edit_hooks:
             self.load_hooks()
 
         if not self.urlwatch_config.edit:
             self.load_jobs()
-
-        if hasattr(self.urlwatch_config, 'migrate_urls'):
-            self.urlwatch_config.migrate_cache(self)
 
     def check_directories(self):
         if not os.path.isdir(self.urlwatch_config.urlwatch_dir):

--- a/lib/urlwatch/migration.py
+++ b/lib/urlwatch/migration.py
@@ -30,7 +30,6 @@
 
 import logging
 import os.path
-import sys
 
 from .util import atomic_rename
 from .storage import UrlsYaml, UrlsTxt, CacheDirStorage
@@ -45,12 +44,6 @@ def migrate_urls(urlwatcher):
     pkgname = urlwatch_config.pkgname
     urls = urlwatch_config.urls
     urls_txt = os.path.join(urlwatch_config.urlwatch_dir, 'urls.txt')
-    edit = urlwatch_config.edit
-    add = urlwatch_config.add
-    features = urlwatch_config.features
-    edit_hooks = urlwatch_config.edit_hooks
-    edit_config = urlwatch_config.edit_config
-    gc_cache = urlwatch_config.gc_cache
 
     if os.path.isfile(urls_txt) and not os.path.isfile(urls):
         print("""
@@ -59,13 +52,6 @@ def migrate_urls(urlwatcher):
     """.format(urls_txt=urls_txt, urls_yaml=urls, pkgname=pkgname))
         UrlsYaml(urls).save(UrlsTxt(urls_txt).load_secure())
         atomic_rename(urls_txt, urls_txt + '.migrated')
-
-    if not any([os.path.isfile(urls), edit, add, features, edit_hooks, edit_config, gc_cache]):
-        print("""
-    You need to create {urls_yaml} in order to use {pkgname}.
-    Use "{pkgname} --edit" to open the file with your editor.
-    """.format(urls_yaml=urls, pkgname=pkgname))
-        sys.exit(1)
 
 
 def migrate_cache(urlwatcher):

--- a/lib/urlwatch/migration.py
+++ b/lib/urlwatch/migration.py
@@ -29,6 +29,7 @@
 
 
 import logging
+import os
 import os.path
 
 from .util import atomic_rename
@@ -49,6 +50,7 @@ def migrate_urls(urlwatch_config):
     Migrating URLs: {urls_txt} -> {urls_yaml}
     Use "{pkgname} --edit" to customize it.
     """.format(urls_txt=urls_txt, urls_yaml=urls, pkgname=pkgname))
+        os.makedirs(os.path.dirname(urls), exist_ok=True)
         UrlsYaml(urls).save(UrlsTxt(urls_txt).load_secure())
         atomic_rename(urls_txt, urls_txt + '.migrated')
 
@@ -66,6 +68,7 @@ def migrate_cache(urlwatch_config):
     Migrating cache: {cache_dir} -> {cache_db}
     """.format(cache_dir=cache_dir, cache_db=cache))
         old_cache_storage = CacheDirStorage(cache_dir)
+        os.makedirs(os.path.dirname(cache), exist_ok=True)
         new_cache_storage = CacheMiniDBStorage(cache)
         new_cache_storage.restore(old_cache_storage.backup())
         new_cache_storage.close()

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -105,16 +105,12 @@ def test_run_watcher():
     cache = os.path.join(os.path.dirname(__file__), 'data', 'cache.db')
     hooks = ''
 
-    config_storage = YamlConfigStorage(config)
-    urls_storage = UrlsYaml(urls)
-    cache_storage = CacheMiniDBStorage(cache)
+    urlwatch_config = TestConfig(config, urls, cache, hooks, True)
+    urlwatcher = Urlwatch(urlwatch_config)
     try:
-        urlwatch_config = TestConfig(config, urls, cache, hooks, True)
-
-        urlwatcher = Urlwatch(urlwatch_config, config_storage, cache_storage, urls_storage)
         urlwatcher.run_jobs()
     finally:
-        cache_storage.close()
+        urlwatcher.cache_storage.close()
 
 
 def test_unserialize_shell_job_without_kind():
@@ -139,42 +135,38 @@ def prepare_retry_test():
     cache = os.path.join(os.path.dirname(__file__), 'data', 'cache.db')
     hooks = ''
 
-    config_storage = YamlConfigStorage(config)
-    cache_storage = CacheMiniDBStorage(cache)
-    urls_storage = UrlsYaml(urls)
-
     urlwatch_config = TestConfig(config, urls, cache, hooks, True)
-    urlwatcher = Urlwatch(urlwatch_config, config_storage, cache_storage, urls_storage)
+    urlwatcher = Urlwatch(urlwatch_config)
 
-    return urlwatcher, cache_storage
+    return urlwatcher
 
 
 @with_setup(teardown=teardown_func)
 def test_number_of_tries_in_cache_is_increased():
-    urlwatcher, cache_storage = prepare_retry_test()
+    urlwatcher = prepare_retry_test()
     try:
         job = urlwatcher.jobs[0]
-        old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
+        old_data, timestamp, tries, etag = urlwatcher.cache_storage.load(job, job.get_guid())
         assert tries == 0
 
         urlwatcher.run_jobs()
         urlwatcher.run_jobs()
 
         job = urlwatcher.jobs[0]
-        old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
+        old_data, timestamp, tries, etag = urlwatcher.cache_storage.load(job, job.get_guid())
 
         assert tries == 2
         assert urlwatcher.report.job_states[-1].verb == 'error'
     finally:
-        cache_storage.close()
+        urlwatcher.cache_storage.close()
 
 
 @with_setup(teardown=teardown_func)
 def test_report_error_when_out_of_tries():
-    urlwatcher, cache_storage = prepare_retry_test()
+    urlwatcher = prepare_retry_test()
     try:
         job = urlwatcher.jobs[0]
-        old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
+        old_data, timestamp, tries, etag = urlwatcher.cache_storage.load(job, job.get_guid())
         assert tries == 0
 
         urlwatcher.run_jobs()
@@ -183,21 +175,21 @@ def test_report_error_when_out_of_tries():
         report = urlwatcher.report
         assert report.job_states[-1].verb == 'error'
     finally:
-        cache_storage.close()
+        urlwatcher.cache_storage.close()
 
 
 @with_setup(teardown=teardown_func)
 def test_reset_tries_to_zero_when_successful():
-    urlwatcher, cache_storage = prepare_retry_test()
+    urlwatcher = prepare_retry_test()
     try:
         job = urlwatcher.jobs[0]
-        old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
+        old_data, timestamp, tries, etag = urlwatcher.cache_storage.load(job, job.get_guid())
         assert tries == 0
 
         urlwatcher.run_jobs()
 
         job = urlwatcher.jobs[0]
-        old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
+        old_data, timestamp, tries, etag = urlwatcher.cache_storage.load(job, job.get_guid())
         assert tries == 1
 
         # use an url that definitely exists
@@ -207,7 +199,7 @@ def test_reset_tries_to_zero_when_successful():
         urlwatcher.run_jobs()
 
         job = urlwatcher.jobs[0]
-        old_data, timestamp, tries, etag = cache_storage.load(job, job.get_guid())
+        old_data, timestamp, tries, etag = urlwatcher.cache_storage.load(job, job.get_guid())
         assert tries == 0
     finally:
-        cache_storage.close()
+        urlwatcher.cache_storage.close()


### PR DESCRIPTION
* Move storage objects creation from `cli.main` to `main.Urlwatch.__init__`
* Move urls file check from `migration.migrate_urls` to `main.Urlwatch.__init__`
* Move migration function calls from `main.Urlwatch.__init__` to `cli.main`

Each bullet point corresponds to one self-contained commit.

Mostly refactoring in preparation for introducing new cache DB.
I feel this way the responsibilities of migration/initialization/validation are better separated/organized.