### PR TITLE
Update hooks importing code

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -28,7 +28,6 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import imp
 import logging
 import os
 import shutil
@@ -39,7 +38,7 @@ from .filters import FilterBase
 from .handler import JobState
 from .jobs import JobBase, UrlJob
 from .reporters import ReporterBase
-from .util import atomic_rename, edit_file
+from .util import atomic_rename, edit_file, import_module_from_source
 from .mailer import set_password, have_password
 
 logger = logging.getLogger(__name__)
@@ -61,7 +60,7 @@ class UrlwatchCommand:
                     self.urlwatch_config.hooks_py_example):
                 shutil.copy(self.urlwatch_config.hooks_py_example, hooks_edit)
             edit_file(hooks_edit)
-            imp.load_source('hooks', hooks_edit)
+            import_module_from_source('hooks', hooks_edit)
             atomic_rename(hooks_edit, self.urlwatch_config.hooks)
             print('Saving edit changes in', self.urlwatch_config.hooks)
         except SystemExit:

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -32,7 +32,6 @@ import re
 import logging
 import itertools
 import os
-import imp
 import html.parser
 import hashlib
 import json
@@ -41,7 +40,7 @@ from enum import Enum
 from lxml import etree
 from lxml.cssselect import CSSSelector
 
-from .util import TrackSubClasses
+from .util import TrackSubClasses, import_module_from_source
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +141,7 @@ class LegacyHooksPyFilter(FilterBase):
         self.hooks = None
         if os.path.exists(self.FILENAME):
             try:
-                self.hooks = imp.load_source('legacy_hooks', self.FILENAME)
+                self.hooks = import_module_from_source('legacy_hooks', self.FILENAME)
             except Exception as e:
                 logger.error('Could not load legacy hooks file: %s', e)
 

--- a/lib/urlwatch/main.py
+++ b/lib/urlwatch/main.py
@@ -28,12 +28,12 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import imp
 import logging
 import os
 
 from .handler import Report
 from .worker import run_jobs
+from .util import import_module_from_source
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class Urlwatch(object):
 
     def load_hooks(self):
         if os.path.exists(self.urlwatch_config.hooks):
-            imp.load_source('hooks', self.urlwatch_config.hooks)
+            import_module_from_source('hooks', self.urlwatch_config.hooks)
 
     def load_jobs(self):
         if os.path.isfile(self.urlwatch_config.urls):

--- a/lib/urlwatch/util.py
+++ b/lib/urlwatch/util.py
@@ -33,6 +33,9 @@ import os
 import platform
 import subprocess
 import shlex
+import importlib.machinery
+import importlib.util
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -99,3 +102,12 @@ def edit_file(filename):
         raise SystemExit('Please set $VISUAL or $EDITOR.')
 
     subprocess.check_call(shlex.split(editor) + [filename])
+
+
+def import_module_from_source(module_name, source_path):
+    loader = importlib.machinery.SourceFileLoader(module_name, source_path)
+    spec = importlib.util.spec_from_file_location(module_name, source_path, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    loader.exec_module(module)
+    return module

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -9,12 +9,12 @@ from nose.tools import raises, with_setup
 
 import tempfile
 import os
-import imp
 
 from urlwatch import storage
 from urlwatch.config import BaseConfig
 from urlwatch.storage import YamlConfigStorage, CacheMiniDBStorage
 from urlwatch.main import Urlwatch
+from urlwatch.util import import_module_from_source
 
 
 def test_required_classattrs_in_subclasses():
@@ -71,7 +71,7 @@ def test_load_urls_yaml():
 def test_load_hooks_py():
     hooks_py = 'share/urlwatch/examples/hooks.py.example'
     if os.path.exists(hooks_py):
-        imp.load_source('hooks', hooks_py)
+        import_module_from_source('hooks', hooks_py)
 
 
 def test_pep8_conformance():


### PR DESCRIPTION
[`imp`](https://docs.python.org/3/library/imp.html) is deprecated.
New implementation is largely the same as the [example](https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly) in `importlib`'s docs.