### PR TITLE
Add mechanism to request/release job resources

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -126,13 +126,13 @@ class UrlwatchCommand:
             # Force re-retrieval of job, as we're testing filters
             job.ignore_cached = True
 
-        job_state = JobState(self.urlwatcher.cache_storage, job)
-        job_state.process()
-        if job_state.exception is not None:
-            raise job_state.exception
-        print(job_state.new_data)
-        # We do not save the job state or job on purpose here, since we are possibly modifying the job
-        # (ignore_cached) and we do not want to store the newly-retrieved data yet (filter testing)
+        with JobState(self.urlwatcher.cache_storage, job) as job_state:
+            job_state.process()
+            if job_state.exception is not None:
+                raise job_state.exception
+            print(job_state.new_data)
+            # We do not save the job state or job on purpose here, since we are possibly modifying the job
+            # (ignore_cached) and we do not want to store the newly-retrieved data yet (filter testing)
         return 0
 
     def modify_urls(self):

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -70,10 +70,8 @@ class JobState(object):
         try:
             self.job.release_resources(JobState.resources)
         except Exception as ex:
-            logger.error('Got exception while releasing resources for job: %r', self.job, exc_info=ex)
-            if self.exception is None:
-                self.exception = ex
-                self.traceback = traceback.format_exc()
+            # Log warning only. We don't want exceptions from releasing resources to override job run results
+            logger.warning('Got exception while releasing resources for job: %r', self.job, exc_info=ex)
 
     def load(self):
         guid = self.job.get_guid()

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 class JobState(object):
-    resouces = {}
+    resources = {}
 
     def __init__(self, cache_storage, job):
         self.cache_storage = cache_storage
@@ -59,7 +59,7 @@ class JobState(object):
 
     def __enter__(self):
         try:
-            self.job.request_resources(JobState.resouces)
+            self.job.request_resources(JobState.resources)
         except Exception as ex:
             self.exception = ex
             self.traceback = traceback.format_exc()
@@ -68,7 +68,7 @@ class JobState(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         try:
-            self.job.release_resources(JobState.resouces)
+            self.job.release_resources(JobState.resources)
         except Exception as ex:
             logger.error('Got exception while releasing resources for job: %r', self.job, exc_info=ex)
             if self.exception is None:

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -160,6 +160,22 @@ class JobBase(object, metaclass=TrackSubClasses):
         sha_hash.update(location.encode('utf-8'))
         return sha_hash.hexdigest()
 
+    def request_resources(self, resources):
+        """Request external resources.
+        Primarily used for resources that are shared or can only be created
+        on the main thread. Check if required resources are available in
+        `resources` (a dict). If not, request and save them in `resources`.
+        Keys should typically be `self` or class, depending on the shared or
+        exclusive nature of the resource.
+        Args:
+            resources: A dict storing external resources.
+        """
+        ...
+
+    def release_resources(self, resources):
+        """Release external resources requested in `request_resources`."""
+        ...
+
     def retrieve(self, job_state):
         raise NotImplementedError()
 

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -31,6 +31,7 @@
 import concurrent.futures
 import logging
 import difflib
+from contextlib import ExitStack
 
 from .handler import JobState
 from .jobs import NotModifiedError
@@ -56,52 +57,55 @@ def run_jobs(urlwatcher):
     report = urlwatcher.report
 
     logger.debug('Processing %d jobs', len(jobs))
-    for job_state in run_parallel(lambda job_state: job_state.process(),
-                                  (JobState(cache_storage, job) for job in jobs)):
-        logger.debug('Job finished: %s', job_state.job)
+    with ExitStack() as exit_stack:
+        for job_state in run_parallel(
+            lambda job_state: job_state.process(),
+            (exit_stack.enter_context(JobState(cache_storage, job)) for job in jobs)
+        ):
+            logger.debug('Job finished: %s', job_state.job)
 
-        if not job_state.job.max_tries:
-            max_tries = 0
-        else:
-            max_tries = job_state.job.max_tries
-        logger.debug('Using max_tries of %i for %s', max_tries, job_state.job)
+            if not job_state.job.max_tries:
+                max_tries = 0
+            else:
+                max_tries = job_state.job.max_tries
+            logger.debug('Using max_tries of %i for %s', max_tries, job_state.job)
 
-        if job_state.exception is not None:
-            if job_state.error_ignored:
-                logger.info('Error while executing job %s ignored due to job config', job_state.job)
-            elif isinstance(job_state.exception, NotModifiedError):
-                logger.info('Job %s has not changed (HTTP 304)', job_state.job)
-                report.unchanged(job_state)
-                if job_state.tries > 0:
-                    job_state.tries = 0
+            if job_state.exception is not None:
+                if job_state.error_ignored:
+                    logger.info('Error while executing job %s ignored due to job config', job_state.job)
+                elif isinstance(job_state.exception, NotModifiedError):
+                    logger.info('Job %s has not changed (HTTP 304)', job_state.job)
+                    report.unchanged(job_state)
+                    if job_state.tries > 0:
+                        job_state.tries = 0
+                        job_state.save()
+                elif job_state.tries < max_tries:
+                    logger.debug('This was try %i of %i for job %s', job_state.tries,
+                                 max_tries, job_state.job)
                     job_state.save()
-            elif job_state.tries < max_tries:
-                logger.debug('This was try %i of %i for job %s', job_state.tries,
-                             max_tries, job_state.job)
-                job_state.save()
-            elif job_state.tries >= max_tries:
-                logger.debug('We are now at %i tries ', job_state.tries)
-                job_state.save()
-                report.error(job_state)
+                elif job_state.tries >= max_tries:
+                    logger.debug('We are now at %i tries ', job_state.tries)
+                    job_state.save()
+                    report.error(job_state)
 
-        elif job_state.old_data is not None:
-            matched_history_time = job_state.history_data.get(job_state.new_data)
-            if matched_history_time:
-                job_state.timestamp = matched_history_time
-            if matched_history_time or job_state.new_data == job_state.old_data:
-                report.unchanged(job_state)
-                if job_state.tries > 0:
+            elif job_state.old_data is not None:
+                matched_history_time = job_state.history_data.get(job_state.new_data)
+                if matched_history_time:
+                    job_state.timestamp = matched_history_time
+                if matched_history_time or job_state.new_data == job_state.old_data:
+                    report.unchanged(job_state)
+                    if job_state.tries > 0:
+                        job_state.tries = 0
+                        job_state.save()
+                else:
+                    close_matches = difflib.get_close_matches(job_state.new_data, job_state.history_data, n=1)
+                    if close_matches:
+                        job_state.old_data = close_matches[0]
+                        job_state.timestamp = job_state.history_data[close_matches[0]]
+                    report.changed(job_state)
                     job_state.tries = 0
                     job_state.save()
             else:
-                close_matches = difflib.get_close_matches(job_state.new_data, job_state.history_data, n=1)
-                if close_matches:
-                    job_state.old_data = close_matches[0]
-                    job_state.timestamp = job_state.history_data[close_matches[0]]
-                report.changed(job_state)
+                report.new(job_state)
                 job_state.tries = 0
                 job_state.save()
-        else:
-            report.new(job_state)
-            job_state.tries = 0
-            job_state.save()


### PR DESCRIPTION
Another new design in preparation for re-implementation of browser job. I feel much happier about this one.

Similar to #355, added `request_resources` and `release_resources` to `JobBase`.
But this time, `JobState` becomes a context manager (inspired by https://github.com/thp/urlwatch/pull/355#discussion_r422605448). It wraps the request/release method calls so exceptions can be captured/reported without crashing the entire run.
The `resources` dict is now better encapsulated as a class variable of `JobState`.

I'm not turning `JobBase` into a context manager, because I still don't want job objects to carry state. I quite like the separation of definition & state between job and job state classes.

To reduce PR size and ease review, this PR doesn't (or at least shouldn't) introduce any functional changes. Real browser job implementation will be in another PR, if this one's approved.

May be desirable to enable "hide whitespace changes" because there are indentation changes.