### PR TITLE
Travis CI: Force pycodestyle==2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ python:
   - "3.8"
 install:
   - pip install -r requirements.txt
-  - pip install pycodestyle
+  - pip install pycodestyle==2.6.0
 script: nosetests -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - `sort` filter: Add `reverse` option to reverse the sorting order
+- Travis CI: Set `pycodestyle` version to 2.6.0 to avoid CI breakage when new style checks are added
 
 
 ## [2.18] -- 2020-05-03


### PR DESCRIPTION
The recently-released pycodestyle 2.6.0 added some new checks that have since been fixed in #499. To avoid random breakage in the future, pin the pycodestyle version to 2.6.0 so that we need to manually upgrade it to newer versions.