### PR TITLE
Added filter to diff results

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -172,7 +172,7 @@ class JobBase(object, metaclass=TrackSubClasses):
 
 class Job(JobBase):
     __required__ = ()
-    __optional__ = ('name', 'filter', 'max_tries', 'diff_tool', 'compared_versions')
+    __optional__ = ('name', 'filter', 'max_tries', 'diff_tool', 'comparison_filter', 'compared_versions')
 
     # determine if hyperlink "a" tag is used in HtmlReporter
     LOCATION_IS_URL = False

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -138,7 +138,6 @@ class ReporterBase(object, metaclass=TrackSubClasses):
         timestamp_old = email.utils.formatdate(job_state.timestamp, localtime=True)
         timestamp_new = email.utils.formatdate(time.time(), localtime=True)
         contextlines = 0 if job_state.job.comparison_filter else 3
-        print(f'{contextlines=}')
         diff = list(difflib.unified_diff(job_state.old_data.splitlines(keepends=True),
                                          job_state.new_data.splitlines(keepends=True),
                                          '@', '@', timestamp_old, timestamp_new, n=contextlines))

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -143,12 +143,12 @@ class ReporterBase(object, metaclass=TrackSubClasses):
                                          '@', '@', timestamp_old, timestamp_new, n=contextlines))
         if job_state.job.comparison_filter == 'additions':
             head = diff[0]
-            diff = [dif for dif in diff if dif.startswith('+')]
+            diff = [dif for dif in diff if dif.startswith('+') or dif.startswith('@')]
             if diff:
                 diff = ['Comparison type: Additions only\n', '   ' + head[3:]] + diff
         if job_state.job.comparison_filter == 'deletions':
             head = diff[1]
-            diff = [dif for dif in diff if dif.startswith('-')]
+            diff = [dif for dif in diff if dif.startswith('-') or dif.startswith('@')]
             if diff:
                 diff = ['Comparison type: Deletions only\n', diff[0], '   ' + head[3:]] + diff[2:]
         return ''.join(diff)


### PR DESCRIPTION
Added job key `comparison_filter` which can take the values of `additions` or `deletions`. It filters the diff to show only additions or deletion lines.

If you like it, will document it as well (have already drafted completely rewritten documentation)

For additions:
```
---------------------------------------------------------------------------
CHANGED: https://example.com
---------------------------------------------------------------------------
Comparison type: Additions only
    @   Sat, 23 May 2020 14:57:03 +0800
+++ @   Sat, 23 May 2020 14:59:04 +0800
@@ -1,2 +1,2 @@
+This is a line that has been added or changed
```
For deletions:
```
---------------------------------------------------------------------------
CHANGED: https://example.com
---------------------------------------------------------------------------
Comparison type: Deletions only
--- @   Sat, 23 May 2020 15:16:48 +0800
    @   Sat, 23 May 2020 15:17:18 +0800
@@ -1,2 +1,2 @@
-This is a line that has been deleted or changed
```