### PR TITLE
Cache unified_diff function

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -118,6 +118,7 @@ class ReporterBase(object, metaclass=TrackSubClasses):
     def submit(self):
         raise NotImplementedError()
 
+    @functools.lru_cache(maxsize=1)
     def unified_diff(self, job_state):
         if job_state.job.diff_tool is not None:
             with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -144,9 +144,7 @@ class ReporterBase(object, metaclass=TrackSubClasses):
 
         timestamp_old = email.utils.formatdate(job_state.timestamp, localtime=1)
         timestamp_new = email.utils.formatdate(time.time(), localtime=1)
-        text = cached_unified_diff(job_state.old_data, job_state.new_data, timestamp_old, timestamp_new)
-        print(cached_unified_diff.cache_info())
-        return text
+        return cached_unified_diff(job_state.old_data, job_state.new_data, timestamp_old, timestamp_new)
 
 
 class SafeHtml(object):


### PR DESCRIPTION
When sending html email the `unified_diff` function is called twice: one to generate `body_text`, and then again when generating `body_html` since the output from `body_text` is not used to generate `body_html`.  Furthermore, if the output to console is enabled the function is called a **_third_** time.

While refactoring the code to avoid such wastage would be ideal, this one liner should speed things up by itself.