### PR TITLE
Move diff code to JobState, cache result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - `sort` filter: Add `separator` option to specify item separator (default is still line-based)
 - Travis CI: Set `pycodestyle` version to 2.6.0 to avoid CI breakage when new style checks are added
 - Most filters that only had unnamed subfilters (e.g. `grep`) now have a named default subfilter
+- Diff results are now runtime cached on a per-job basis, which shouldn't affect behavior, but
+  could be observed by an external `diff_tool` running at most once per job instead of multiple times
 
 ### Deprecated
 

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -32,6 +32,12 @@ import datetime
 import logging
 import time
 import traceback
+import tempfile
+import difflib
+import os
+import shlex
+import subprocess
+import email.utils
 
 from .filters import FilterBase
 from .jobs import NotModifiedError
@@ -54,6 +60,7 @@ class JobState(object):
         self.tries = 0
         self.etag = None
         self.error_ignored = False
+        self._generated_diff = None
 
     def load(self):
         guid = self.job.get_guid()
@@ -104,6 +111,35 @@ class JobState(object):
                 logger.debug('Increasing number of tries to %i for %s', self.tries, self.job)
 
         return self
+
+    def get_diff(self):
+        if self._generated_diff is None:
+            self._generated_diff = self._generate_diff()
+
+        return self._generated_diff
+
+    def _generate_diff(self):
+        if self.job.diff_tool is not None:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                old_file_path = os.path.join(tmpdir, 'old_file')
+                new_file_path = os.path.join(tmpdir, 'new_file')
+                with open(old_file_path, 'w+b') as old_file, open(new_file_path, 'w+b') as new_file:
+                    old_file.write(self.old_data.encode('utf-8'))
+                    new_file.write(self.new_data.encode('utf-8'))
+                cmdline = shlex.split(self.job.diff_tool) + [old_file_path, new_file_path]
+                proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+                stdout, _ = proc.communicate()
+                # Diff tools return 0 for "nothing changed" or 1 for "files differ", anything else is an error
+                if proc.returncode in (0, 1):
+                    return stdout.decode('utf-8')
+                else:
+                    raise subprocess.CalledProcessError(proc.returncode, cmdline)
+
+        timestamp_old = email.utils.formatdate(self.timestamp, localtime=True)
+        timestamp_new = email.utils.formatdate(time.time(), localtime=True)
+        return ''.join(difflib.unified_diff(self.old_data.splitlines(keepends=True),
+                                            self.new_data.splitlines(keepends=True),
+                                            '@', '@', timestamp_old, timestamp_new))
 
 
 class Report(object):

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -28,14 +28,10 @@
 
 
 import difflib
-import tempfile
-import subprocess
 import re
-import shlex
 import email.utils
 import itertools
 import logging
-import os
 import sys
 import time
 import html
@@ -117,29 +113,6 @@ class ReporterBase(object, metaclass=TrackSubClasses):
 
     def submit(self):
         raise NotImplementedError()
-
-    def unified_diff(self, job_state):
-        if job_state.job.diff_tool is not None:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                old_file_path = os.path.join(tmpdir, 'old_file')
-                new_file_path = os.path.join(tmpdir, 'new_file')
-                with open(old_file_path, 'w+b') as old_file, open(new_file_path, 'w+b') as new_file:
-                    old_file.write(job_state.old_data.encode('utf-8'))
-                    new_file.write(job_state.new_data.encode('utf-8'))
-                cmdline = shlex.split(job_state.job.diff_tool) + [old_file_path, new_file_path]
-                proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
-                stdout, _ = proc.communicate()
-                # Diff tools return 0 for "nothing changed" or 1 for "files differ", anything else is an error
-                if proc.returncode in (0, 1):
-                    return stdout.decode('utf-8')
-                else:
-                    raise subprocess.CalledProcessError(proc.returncode, cmdline)
-
-        timestamp_old = email.utils.formatdate(job_state.timestamp, localtime=True)
-        timestamp_new = email.utils.formatdate(time.time(), localtime=True)
-        return ''.join(difflib.unified_diff(job_state.old_data.splitlines(keepends=True),
-                                            job_state.new_data.splitlines(keepends=True),
-                                            '@', '@', timestamp_old, timestamp_new))
 
 
 class SafeHtml(object):
@@ -241,7 +214,7 @@ class HtmlReporter(ReporterBase):
         elif difftype == 'unified':
             return ''.join((
                 '<pre>',
-                '\n'.join(self._diff_to_html(self.unified_diff(job_state))),
+                '\n'.join(self._diff_to_html(job_state.get_diff())),
                 '</pre>',
             ))
         else:
@@ -298,7 +271,7 @@ class TextReporter(ReporterBase):
         if job_state.old_data in (None, job_state.new_data):
             return None
 
-        return self.unified_diff(job_state)
+        return job_state.get_diff()
 
     def _format_output(self, job_state, line_length):
         summary_part = []
@@ -689,7 +662,7 @@ class MarkdownReporter(ReporterBase):
         if job_state.old_data in (None, job_state.new_data):
             return None
 
-        return self.unified_diff(job_state)
+        return job_state.get_diff()
 
     def _format_output(self, job_state):
         summary_part = []


### PR DESCRIPTION
This supersedes #506, with the following changes:

- Caching is done explicitly in `JobState`
- Also caches external (`diff_tool`) results
- Since the function has more to do with `JobState` than `ReporterBase`, move it there

It will also allow future improvements (e.g. not reporting changes if the diff is empty, even if the contents change), because now we have access to the diff from the `job_state`, not requiring a reporter at all.