### PR TITLE
Fixed detection of is_bytes_filter

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -201,8 +201,8 @@ class ShellJob(Job):
 
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
-        if self.filter and (FilterBase.is_bytes_filter(self.filter)
-                            or FilterBase.is_bytes_filter(next(iter(self.filter[0])))):
+        if self.filter and (FilterBase.is_bytes_filter(self.filter[0])
+                            or FilterBase.is_bytes_filter(self.filter)):
             return stdout_data
 
         return stdout_data.decode('utf-8')
@@ -293,8 +293,8 @@ class UrlJob(Job):
 
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
-        if self.filter and (FilterBase.is_bytes_filter(self.filter)
-                            or FilterBase.is_bytes_filter(next(iter(self.filter[0])))):
+        if self.filter and (FilterBase.is_bytes_filter(self.filter[0])
+                            or FilterBase.is_bytes_filter(self.filter)):
             return response.content
 
         # If we can't find the encoding in the headers, requests gets all

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -201,7 +201,8 @@ class ShellJob(Job):
 
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
-        if self.filter and (FilterBase.is_bytes_filter(self.filter[0])
+        if self.filter and (FilterBase.is_bytes_filter(next(iter(self.filter[0])))
+                            or FilterBase.is_bytes_filter(self.filter[0])
                             or FilterBase.is_bytes_filter(self.filter)):
             return stdout_data
 
@@ -293,7 +294,8 @@ class UrlJob(Job):
 
         # If the first filter is a bytes filter, return content in bytes instead of in unicode
         # as that's what's required by the library used by that filter
-        if self.filter and (FilterBase.is_bytes_filter(self.filter[0])
+        if self.filter and (FilterBase.is_bytes_filter(next(iter(self.filter[0])))
+                            or FilterBase.is_bytes_filter(self.filter[0])
                             or FilterBase.is_bytes_filter(self.filter)):
             return response.content
 


### PR DESCRIPTION
`pdf2text` fails when declared using new dict-style filter definition normalization/mapping:

```
---------------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\program files\python\python38\lib\site-packages\urlwatch\handler.py", line 92, in process
    data = FilterBase.process(filter_kind, subfilter, self, data)
  File "c:\program files\python\python38\lib\site-packages\urlwatch\filters.py", line 145, in process
    return filtercls(state.job, state).filter(data, subfilter)
  File "c:\program files\python\python38\lib\site-packages\urlwatch\filters.py", line 286, in filter
    raise ValueError('The pdf2text filter needs bytes input (is it the first filter?)')
ValueError: The pdf2text filter needs bytes input (is it the first filter?)
---------------------------------------------------------------------------
```

Fixed incorrect detection of whether first filter `is_bytes_filter` (my code, take full responsibility).  Also reversed order of testing to prioritize new dict-style filter definition.

Not sure why unit testing didn't catch that; `test\test_filters.py` is not documented and don't quite know what to change to fix this.

Manually unit tested both scenarios of when filter is declared as a string and as dict-style.