### PR TITLE
Add --test-diff-filter command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Documentation now has a section on the configuration settings (`--edit-config`)
 - IFTTT reporter (#512, by Florian Gaultier)
 - New filter: ``ocr`` to convert text in images to plaintext (using Tesseract OCR)
+- Add `--test-diff-filter` command-line option that can test the `diff_tool` and
+  `diff_filter` settings for a job (needs at least 2 historic snapshots)
 
 ### Changed
 

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -34,6 +34,11 @@ already filtered when it was retrieved. This means that changes to
 will be between (old content with filter at the time old content was
 retrieved) and (new content with current filter).
 
+Once urlwatch has collected at least 2 historic snapshots of a job
+(two different states of a webpage) you can use the command-line
+option ``--test-diff-filter`` to test your ``diff_filter`` settings;
+this will use historic data cached locally.
+
 
 Built-in filters
 ----------------

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -111,10 +111,10 @@ Optional keys for all job types
 -------------------------------
 
 - ``name``: Human-readable name/label of the job
-- ``filter``: :ref:`filters` (if any) to apply to the output
+- ``filter``: :ref:`filters` (if any) to apply to the output (can be tested with ``--test-filter``)
 - ``max_tries``: Number of times to retry fetching the resource
 - ``diff_tool``: Command to a custom tool for generating diff text
-- ``diff_filter``: :ref:`filters` (if any) to apply to the diff result
+- ``diff_filter``: :ref:`filters` (if any) to apply to the diff result (can be tested with ``--test-diff-filter``)
 - ``compared_versions``: Number of versions to compare for similarity
 - ``kind`` (redundant): Either ``url``, ``shell`` or ``browser``.  Automatically derived from the unique key (``url``, ``command`` or ``navigate``) of the job type
 

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -97,6 +97,8 @@ class CommandConfig(BaseConfig):
         group.add_argument('--add', metavar='JOB', help='add job (key1=value1,key2=value2,...)')
         group.add_argument('--delete', metavar='JOB', help='delete job by location or index')
         group.add_argument('--test-filter', metavar='JOB', help='test filter output of job by location or index')
+        group.add_argument('--test-diff-filter', metavar='JOB',
+                           help='test diff filter output of job by location or index (needs at least 2 snapshots)')
         group = parser.add_argument_group('interactive commands ($EDITOR/$VISUAL)')
         group.add_argument('--edit', action='store_true', help='edit URL/job list')
         group.add_argument('--edit-config', action='store_true', help='edit configuration file')


### PR DESCRIPTION
Makes it possible to test the diff filter if at least 2 historic snapshots are saved in the cache.