### PR TITLE
shellpipe: Inherit environment variables (Fixes #541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Unit tests have been migrated from `nose` to `pytest`
   and moved from `test/` to `lib/urlwatch/tests/`
 - The ``css`` and ``xpath`` filters now accept ``skip`` and ``maxitems`` as subfilter
+- The ``shellpipe`` filter now inherits all environment variables (e.g. ``$PATH``)
+  of the ``urlwatch`` process
 
 ### Fixed
 

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -788,10 +788,12 @@ class ShellPipeFilter(FilterBase):
 
         encoding = sys.getdefaultencoding()
 
-        env = {
+        # Work on a copy to not modify the outside environment
+        env = dict(os.environ)
+        env.update({
             'URLWATCH_JOB_NAME': self.job.pretty_name() if self.job else '',
             'URLWATCH_JOB_LOCATION': self.job.get_location() if self.job else '',
-        }
+        })
 
         return subprocess.check_output(subfilter['command'], shell=True,
                                        input=data.encode(encoding), env=env).decode(encoding)

--- a/lib/urlwatch/tests/test_filters.py
+++ b/lib/urlwatch/tests/test_filters.py
@@ -71,3 +71,20 @@ def test_providing_subfilter_to_filter_without_subfilter_raises_valueerror():
 def test_providing_unknown_subfilter_raises_valueerror():
     with pytest.raises(ValueError):
         list(FilterBase.normalize_filter_list([{'grep': {'re': 'Price: .*', 'anothersubfilter': '42'}}]))
+
+
+def test_shellpipe_inherits_environment_but_does_not_modify_it():
+    # https://github.com/thp/urlwatch/issues/541
+
+    # Set a specific value to check it doesn't overwrite the current env
+    os.environ['URLWATCH_JOB_NAME'] = 'should-not-be-overwritten'
+
+    # See if the shellpipe process can use a variable from the outside
+    os.environ['INHERITED_FROM'] = 'parent-process'
+    filtercls = FilterBase.__subclasses__.get('shellpipe')
+    result = filtercls(None, None).filter('input-string', {'command': 'echo "$INHERITED_FROM/$URLWATCH_JOB_NAME"'})
+    # Check that the inherited value and the job name is set properly
+    assert result == 'parent-process/\n'
+
+    # Check that outside the variable wasn't overwritten by the filter
+    assert os.environ['URLWATCH_JOB_NAME'] == 'should-not-be-overwritten'


### PR DESCRIPTION
This should make `shellpipe` a bit more useful.