### PR TITLE
Add --test-reporter option (Fixes #400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [UNRELEASED]
+
+### Added
+
+- Added `--test-reporter REPORTER` command-line option to send an
+  example report using any configured notification service
+
+### Removed
+
+- The `--test-slack` command line option has been removed, you can
+  test your Slack reporter configuration using `--test-reporter slack`
+
+
 ## [2.20] -- 2020-07-29
 
 ### Added

--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -14,6 +14,26 @@ dependencies installed.
 
 See :ref:`configuration` on how to edit the configuration.
 
+To send a test notification, use the ``--test-reporter`` command-line option
+with the name of the reporter::
+
+    urlwatch --test-reporter stdout
+
+This will create a test report with ``new``, ``changed``, ``unchanged`` and
+``error`` notifications (only the ones configured in ``display`` in the
+:ref:`configuration` will be shown in the report) and send it via the
+``stdout`` reporter (if it is enabled).
+
+To test if your e-mail reporter is configured correctly, you can use::
+
+   urlwatch --test-reporter email
+
+Any reporter that is configured and enabled can be tested.
+
+If the notification does not work, check your configuration and/or add
+the ``--verbose`` command-line option to show detailed debug logs.
+
+
 Built-in reporters
 ------------------
 
@@ -121,8 +141,6 @@ To set up Slack, from you Slack Team, create a new app and activate
 “Incoming Webhooks” on a channel, you’ll get a webhook URL, copy it into
 the configuration as seen above.
 
-You can use the command ``urlwatch --test-slack`` to test if the Slack
-integration works.
 
 IFTTT
 -----

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -90,7 +90,7 @@ class CommandConfig(BaseConfig):
         group = parser.add_argument_group('Authentication')
         group.add_argument('--smtp-login', action='store_true', help='Enter password for SMTP (store in keyring)')
         group.add_argument('--telegram-chats', action='store_true', help='List telegram chats the bot is joined to')
-        group.add_argument('--test-slack', action='store_true', help='Send a test notification to Slack')
+        group.add_argument('--test-reporter', metavar='REPORTER', help='Send a test notification')
         group.add_argument('--xmpp-login', action='store_true', help='Enter password for XMPP (store in keyring)')
 
         group = parser.add_argument_group('job list management')

--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -182,3 +182,9 @@ class Report(object):
         duration = (end - self.start)
 
         ReporterBase.submit_all(self, self.job_states, duration)
+
+    def finish_one(self, name):
+        end = datetime.datetime.now()
+        duration = (end - self.start)
+
+        ReporterBase.submit_one(name, self, self.job_states, duration)

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -101,6 +101,15 @@ class ReporterBase(object, metaclass=TrackSubClasses):
         return '\n'.join(result)
 
     @classmethod
+    def submit_one(cls, name, report, job_states, duration):
+        subclass = cls.__subclasses__[name]
+        cfg = report.config['report'].get(name, {'enabled': False})
+        if cfg['enabled']:
+            subclass(report, cfg, job_states, duration).submit()
+        else:
+            raise ValueError('Reporter not enabled: {name}'.format(name=name))
+
+    @classmethod
     def submit_all(cls, report, job_states, duration):
         any_enabled = False
         for name, subclass in cls.__subclasses__.items():


### PR DESCRIPTION
Make it possible to test any reporter and send a more representative report of how a change notification would look like by fabricating a `Report` object.