### PR TITLE
Fix "browser" jobs, switch to Pyppeteer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - The `--test-slack` command line option has been removed, you can
   test your Slack reporter configuration using `--test-reporter slack`
 
+### Changed
+
+- The `browser` job now uses Pyppeteer instead of Requests-HTML for
+  rendering pages while executing JavaScript
+
 
 ## [2.20] -- 2020-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - `JobBase` now has `main_thread_enter()` and `main_thread_exit()`
   functions that can be overridden by subclasses to run code in
   the main thread before and after processing of a job
+  (based on an initial implementation by Chenfeng Bao)
 
 ### Removed
 
@@ -22,7 +23,8 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - The `browser` job now uses Pyppeteer instead of Requests-HTML for
-  rendering pages while executing JavaScript
+  rendering pages while executing JavaScript; this makes JavaScript
+  execution work properly (based on code by Chenfeng Bao)
 
 
 ## [2.20] -- 2020-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - Added `--test-reporter REPORTER` command-line option to send an
   example report using any configured notification service
+- `JobBase` now has `main_thread_enter()` and `main_thread_exit()`
+  functions that can be overridden by subclasses to run code in
+  the main thread before and after processing of a job
 
 ### Removed
 

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -48,7 +48,7 @@ Where ``<packagename>`` is one of the following:
 | `stdout` reporter with  | `colorama <https://github.com/tartley/colorama>`__                  |
 | color on Windows        |                                                                     |
 +-------------------------+---------------------------------------------------------------------+
-| `browser` job kind      | `requests-html <https://html.python-requests.org>`__                |
+| `browser` job kind      | `pyppeteer <https://github.com/pyppeteer/pyppeteer>`__              |
 +-------------------------+---------------------------------------------------------------------+
 | Unit testing            | `pycodestyle <http://pycodestyle.pycqa.org/en/latest/>`__,          |
 |                         | `docutils <https://docutils.sourceforge.io>`__,                     |

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -56,7 +56,7 @@ Navigate
 This job type is a resource-intensive variant of "URL" to handle web pages
 requiring JavaScript in order to render the content to be monitored.
 
-The optional ``requests-html`` package must be installed to run "Navigate" jobs
+The optional ``pyppeteer`` package must be installed to run "Navigate" jobs
 (see :ref:`dependencies`).
 
 .. code-block:: yaml
@@ -72,7 +72,7 @@ Job-specific optional keys:
 
 - none
 
-As this job uses `Requests-HTML <http://html.python-requests.org>`__
+As this job uses `Pyppeteer <https://github.com/pyppeteer/pyppeteer>`__
 to render the page in a headless Chromium instance, it requires massively
 more resources than a "URL" job. Use it only on pages where ``url`` does not
 give the right results.

--- a/lib/urlwatch/browser.py
+++ b/lib/urlwatch/browser.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of urlwatch (https://thp.io/2008/urlwatch/).
+# Copyright (c) 2008-2020 Thomas Perl <m@thp.io>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import logging
+
+import pyppeteer
+import asyncio
+import threading
+
+from .cli import setup_logger
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserLoop(object):
+    def __init__(self):
+        self._event_loop = asyncio.new_event_loop()
+        self._browser = self._event_loop.run_until_complete(self._launch_browser())
+        self._loop_thread = threading.Thread(target=self._event_loop.run_forever)
+        self._loop_thread.start()
+
+    @asyncio.coroutine
+    def _launch_browser(self):
+        browser = yield from pyppeteer.launch()
+        for p in (yield from browser.pages()):
+            yield from p.close()
+        return browser
+
+    @asyncio.coroutine
+    def _get_content(self, url):
+        context = yield from self._browser.createIncognitoBrowserContext()
+        page = yield from context.newPage()
+        yield from page.goto(url)
+        content = yield from page.content()
+        yield from context.close()
+        return content
+
+    def process(self, url):
+        return asyncio.run_coroutine_threadsafe(self._get_content(url), self._event_loop).result()
+
+    def destroy(self):
+        self._event_loop.call_soon_threadsafe(self._event_loop.stop)
+        self._loop_thread.join()
+        self._loop_thread = None
+        self._event_loop.run_until_complete(self._browser.close())
+        self._browser = None
+        self._event_loop = None
+
+
+class BrowserContext(object):
+    _BROWSER_LOOP = None
+    _BROWSER_LOCK = threading.Lock()
+    _BROWSER_REFCNT = 0
+
+    def __init__(self):
+        with BrowserContext._BROWSER_LOCK:
+            if BrowserContext._BROWSER_REFCNT == 0:
+                logger.info('Creating browser main loop')
+                BrowserContext._BROWSER_LOOP = BrowserLoop()
+            BrowserContext._BROWSER_REFCNT += 1
+
+    def process(self, url):
+        return BrowserContext._BROWSER_LOOP.process(url)
+
+    def close(self):
+        with BrowserContext._BROWSER_LOCK:
+            BrowserContext._BROWSER_REFCNT -= 1
+            if BrowserContext._BROWSER_REFCNT == 0:
+                logger.info('Destroying browser main loop')
+                BrowserContext._BROWSER_LOOP.destroy()
+                BrowserContext._BROWSER_LOOP = None
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Browser handler')
+    parser.add_argument('url', help='URL to retrieve')
+    parser.add_argument('-v', '--verbose', action='store_true', help='show debug output')
+    args = parser.parse_args()
+
+    setup_logger(args.verbose)
+
+    try:
+        ctx = BrowserContext()
+        print(ctx.process(args.url))
+    finally:
+        ctx.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -369,8 +369,12 @@ class BrowserJob(Job):
     def get_location(self):
         return self.navigate
 
+    def main_thread_enter(self):
+        from .browser import BrowserContext
+        self.ctx = BrowserContext()
+
+    def main_thread_exit(self):
+        self.ctx.close()
+
     def retrieve(self, job_state):
-        from requests_html import HTMLSession
-        session = HTMLSession()
-        response = session.get(self.navigate)
-        return response.html.html
+        return self.ctx.process(self.navigate)

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -163,6 +163,14 @@ class JobBase(object, metaclass=TrackSubClasses):
     def retrieve(self, job_state):
         raise NotImplementedError()
 
+    def main_thread_enter(self):
+        """Called from the main thread before running the job"""
+        ...
+
+    def main_thread_exit(self):
+        """Called from the main thread after running the job"""
+        ...
+
     def format_error(self, exception, tb):
         return tb
 

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -31,6 +31,7 @@
 import concurrent.futures
 import logging
 import difflib
+import contextlib
 
 from .handler import JobState
 from .jobs import NotModifiedError
@@ -56,52 +57,53 @@ def run_jobs(urlwatcher):
     report = urlwatcher.report
 
     logger.debug('Processing %d jobs', len(jobs))
-    for job_state in run_parallel(lambda job_state: job_state.process(),
-                                  (JobState(cache_storage, job) for job in jobs)):
-        logger.debug('Job finished: %s', job_state.job)
+    with contextlib.ExitStack() as exit_stack:
+        for job_state in run_parallel(lambda job_state: job_state.process(),
+                                      (exit_stack.enter_context(JobState(cache_storage, job)) for job in jobs)):
+            logger.debug('Job finished: %s', job_state.job)
 
-        if not job_state.job.max_tries:
-            max_tries = 0
-        else:
-            max_tries = job_state.job.max_tries
-        logger.debug('Using max_tries of %i for %s', max_tries, job_state.job)
+            if not job_state.job.max_tries:
+                max_tries = 0
+            else:
+                max_tries = job_state.job.max_tries
+            logger.debug('Using max_tries of %i for %s', max_tries, job_state.job)
 
-        if job_state.exception is not None:
-            if job_state.error_ignored:
-                logger.info('Error while executing job %s ignored due to job config', job_state.job)
-            elif isinstance(job_state.exception, NotModifiedError):
-                logger.info('Job %s has not changed (HTTP 304)', job_state.job)
-                report.unchanged(job_state)
-                if job_state.tries > 0:
-                    job_state.tries = 0
+            if job_state.exception is not None:
+                if job_state.error_ignored:
+                    logger.info('Error while executing job %s ignored due to job config', job_state.job)
+                elif isinstance(job_state.exception, NotModifiedError):
+                    logger.info('Job %s has not changed (HTTP 304)', job_state.job)
+                    report.unchanged(job_state)
+                    if job_state.tries > 0:
+                        job_state.tries = 0
+                        job_state.save()
+                elif job_state.tries < max_tries:
+                    logger.debug('This was try %i of %i for job %s', job_state.tries,
+                                 max_tries, job_state.job)
                     job_state.save()
-            elif job_state.tries < max_tries:
-                logger.debug('This was try %i of %i for job %s', job_state.tries,
-                             max_tries, job_state.job)
-                job_state.save()
-            elif job_state.tries >= max_tries:
-                logger.debug('We are now at %i tries ', job_state.tries)
-                job_state.save()
-                report.error(job_state)
+                elif job_state.tries >= max_tries:
+                    logger.debug('We are now at %i tries ', job_state.tries)
+                    job_state.save()
+                    report.error(job_state)
 
-        elif job_state.old_data is not None:
-            matched_history_time = job_state.history_data.get(job_state.new_data)
-            if matched_history_time:
-                job_state.timestamp = matched_history_time
-            if matched_history_time or job_state.new_data == job_state.old_data:
-                report.unchanged(job_state)
-                if job_state.tries > 0:
+            elif job_state.old_data is not None:
+                matched_history_time = job_state.history_data.get(job_state.new_data)
+                if matched_history_time:
+                    job_state.timestamp = matched_history_time
+                if matched_history_time or job_state.new_data == job_state.old_data:
+                    report.unchanged(job_state)
+                    if job_state.tries > 0:
+                        job_state.tries = 0
+                        job_state.save()
+                else:
+                    close_matches = difflib.get_close_matches(job_state.new_data, job_state.history_data, n=1)
+                    if close_matches:
+                        job_state.old_data = close_matches[0]
+                        job_state.timestamp = job_state.history_data[close_matches[0]]
+                    report.changed(job_state)
                     job_state.tries = 0
                     job_state.save()
             else:
-                close_matches = difflib.get_close_matches(job_state.new_data, job_state.history_data, n=1)
-                if close_matches:
-                    job_state.old_data = close_matches[0]
-                    job_state.timestamp = job_state.history_data[close_matches[0]]
-                report.changed(job_state)
+                report.new(job_state)
                 job_state.tries = 0
                 job_state.save()
-        else:
-            report.new(job_state)
-            job_state.tries = 0
-            job_state.save()


### PR DESCRIPTION
This is very much based on @cfbao's PRs #500 and #355, with some changes:

- All pyppeteer-related code moved to `lib/urlwatch/browser.py`
- Jobs get `main_thread_enter()` and `main_thread_exit()` calls
- `BrowserJob` takes care (together with `BrowserContext`) of managing resources

Best viewed with "ignore whitespace changes", since there were some context managers added.

The `urlwatch.browser` module can also be used as main module and accepts a URL that will be retrieved and the content printed on stdout (mostly used for local testing, but doesn't hurt to have it in there).