### PR TITLE
Fix diff generation for lines without newline

### DIFF
--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -161,9 +161,9 @@ class JobState(object):
 
         timestamp_old = email.utils.formatdate(self.timestamp, localtime=True)
         timestamp_new = email.utils.formatdate(time.time(), localtime=True)
-        return ''.join(difflib.unified_diff(self.old_data.splitlines(keepends=True),
-                                            self.new_data.splitlines(keepends=True),
-                                            '@', '@', timestamp_old, timestamp_new))
+        return '\n'.join(difflib.unified_diff(self.old_data.splitlines(),
+                                              self.new_data.splitlines(),
+                                              '@', '@', timestamp_old, timestamp_new, lineterm=''))
 
 
 class Report(object):


### PR DESCRIPTION
Rather than keeping the line endings before passing to diff, then joining the resulting lines with '', strip the line endings and join
with '\n'. This ensures a that each output line has exactly one trailing newline.

Possible issues:
 - This will prevent detection of a difference in line endings.
 - Joining with `os.linesep` might be better for Windows, but only if it is going to a text file, and I think most Windows stuff handles lines terminated with just LF fine now.