### PR TITLE
Add wait_until option to browser jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .idea
 build
+*.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 ## [UNRELEASED]
 
+### Added
+
+- Added 'wait_until' option to browser jobs to configure how long
+  the headless browser will wait for pages to load.
+
 ### Changed
 
 - Diff output is now generated more uniformly, independent of whether

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -258,3 +258,15 @@ a frontend (with GUI) to ``urlwatch``. The tool can be used to
 select a region of a web page. It then generates a configuration
 for ``urlwatch`` to run ``pyvisualcompare`` and generate a hash
 for the screen contents.
+
+
+Configuring how long browser jobs wait for pages to load
+--------------------------------------------------------
+
+For browser jobs, you can configure how long the headless browser will wait
+before a page is considered loaded by using the `wait_until` option. It can take one of four values:
+
+  - `load` will wait until the `load` browser event is fired (default).
+  - `documentloaded` will wait until the `DOMContentLoaded` browser event is fired.
+  - `networkidle0` will wait until there are no more than 0 network connections for at least 500 ms.
+  - `networkidle2` will wait until there are no more than 2 network connections for at least 500 ms.

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -3,7 +3,7 @@
 Jobs
 ====
 
-Jobs are the kind of things that `urlwatch` can monitor. 
+Jobs are the kind of things that `urlwatch` can monitor.
 
 The list of jobs to run are contained in the configuration file ``urls.yaml``,
 accessed with the command ``urlwatch --edit``, each separated by a line
@@ -80,7 +80,8 @@ Required keys:
 
 Job-specific optional keys:
 
-- none
+- ``wait_until``:  Either ``load``, ``domcontentloaded``, ``networkidle0``, or ``networkidle2`` (see :ref:`advanced_topics`)
+
 
 As this job uses `Pyppeteer <https://github.com/pyppeteer/pyppeteer>`__
 to render the page in a headless Chromium instance, it requires massively

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -364,6 +364,8 @@ class BrowserJob(Job):
 
     __required__ = ('navigate',)
 
+    __optional__ = ('wait_until',)
+
     LOCATION_IS_URL = True
 
     def get_location(self):
@@ -377,4 +379,4 @@ class BrowserJob(Job):
         self.ctx.close()
 
     def retrieve(self, job_state):
-        return self.ctx.process(self.navigate)
+        return self.ctx.process(self.navigate, wait_until=self.wait_until)


### PR DESCRIPTION
Addresses https://github.com/thp/urlwatch/issues/548. 

Only long-term concern here is that this extent to which this couples the browser job to pyppeteer. 