### PR TITLE
WIP: Add RSS Reporter

### DIFF
--- a/lib/urlwatch/handler.py
+++ b/lib/urlwatch/handler.py
@@ -133,16 +133,16 @@ class JobState(object):
 
         return self
 
-    def get_diff(self):
+    def get_diff(self, new_time=None):
         if self._generated_diff is None:
-            self._generated_diff = self._generate_diff()
+            self._generated_diff = self._generate_diff(new_time)
             # Apply any specified diff filters
             for filter_kind, subfilter in FilterBase.normalize_filter_list(self.job.diff_filter):
                 self._generated_diff = FilterBase.process(filter_kind, subfilter, self, self._generated_diff)
 
         return self._generated_diff
 
-    def _generate_diff(self):
+    def _generate_diff(self, new_time=None):
         if self.job.diff_tool is not None:
             with tempfile.TemporaryDirectory() as tmpdir:
                 old_file_path = os.path.join(tmpdir, 'old_file')
@@ -160,7 +160,8 @@ class JobState(object):
                     raise subprocess.CalledProcessError(proc.returncode, cmdline)
 
         timestamp_old = email.utils.formatdate(self.timestamp, localtime=True)
-        timestamp_new = email.utils.formatdate(time.time(), localtime=True)
+        timestamp_new = email.utils.formatdate(new_time if new_time is not None else time.time(),
+                                               localtime=True)
         return '\n'.join(difflib.unified_diff(self.old_data.splitlines(),
                                               self.new_data.splitlines(),
                                               '@', '@', timestamp_old, timestamp_new, lineterm=''))

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -252,7 +252,7 @@ class RSSReporter(HtmlReporter):
             E.description(etree.CDATA(html_diff)),
             E.link(tempjs.job.get_location()) if tempjs.job.LOCATION_IS_URL else None,
             E.guid({'isPermaLink': "false"},  tempjs.job.get_guid() + '.' + str(new_ts)),
-            E.pubDate( email.utils.formatdate(new_ts, usegmt=True)))
+            E.pubDate(email.utils.formatdate(new_ts, usegmt=True)))
 
     def _diffs(self, max_history):
         for job_state in self.job_states:
@@ -265,8 +265,9 @@ class RSSReporter(HtmlReporter):
     def submit(self):
         cfg = self.report.config['report']['rss']
         max_history_per_job = cfg['max_history_per_job']
+        output_file = cfg['output_file']
 
-        with open("/home/adam/scratch/test.rss", "wb") as f:
+        with open(output_file, "wb") as f:
             tree = etree.ElementTree(
                 E.rss({'version': '2.0'},
                       E.channel(

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -245,7 +245,7 @@ class RSSReporter(HtmlReporter):
         tempjs.old_data = old_ver
         tempjs.timestamp = old_ts
         tempjs.new_data = new_ver
-        diff = tempjs.get_diff()
+        diff = tempjs.get_diff(new_ts)
         html_diff = etree.tostring(E.pre(diff))
         return E.item(
             E.title(tempjs.job.pretty_name()),


### PR DESCRIPTION
This is a work in progress attempt at a RSS reporter. It retrieves job history and compares each version with the previous one to generate a hopefully stable RSS feed.

I have not tested this very thoroughly (it has no tests, but neither do the other reporters) and it is missing documentation, among other things.

I suspect this will either break or be able to be improved once #360 (or equivalent) is merged.

Resolves #53.