### PR TITLE
Enable configuring max message length for Slack-compatible webhooks

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -610,9 +610,12 @@ class TelegramReporter(TextReporter):
 
 class SlackReporter(TextReporter):
     """Send a message to a Slack channel"""
-    MAX_LENGTH = 40000
 
     __kind__ = 'slack'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.MAX_LENGTH = self.config['max_message_length'] or 40000
 
     def submit(self):
         webhook_url = self.config['webhook_url']

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -615,7 +615,7 @@ class SlackReporter(TextReporter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.MAX_LENGTH = self.config['max_message_length'] or 40000
+        self.MAX_LENGTH = self.config.get('max_message_length', 40000)
 
     def submit(self):
         webhook_url = self.config['webhook_url']

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -615,7 +615,7 @@ class SlackReporter(TextReporter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.MAX_LENGTH = self.config.get('max_message_length', 40000)
+        self.max_length = self.config.get('max_message_length', 40000)
 
     def submit(self):
         webhook_url = self.config['webhook_url']
@@ -626,7 +626,7 @@ class SlackReporter(TextReporter):
             return
 
         result = None
-        for chunk in chunkstring(text, self.MAX_LENGTH, numbering=True):
+        for chunk in chunkstring(text, self.max_length, numbering=True):
             res = self.submit_to_slack(webhook_url, chunk)
             if res.status_code != requests.codes.ok or res is None:
                 result = res

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -124,7 +124,7 @@ DEFAULT_CONFIG = {
         'slack': {
             'enabled': False,
             'webhook_url': '',
-            'max_message_length': 40000
+            'max_message_length': 40000,
         },
         'matrix': {
             'enabled': False,

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -124,6 +124,7 @@ DEFAULT_CONFIG = {
         'slack': {
             'enabled': False,
             'webhook_url': '',
+            'max_message_length': 40000
         },
         'matrix': {
             'enabled': False,


### PR DESCRIPTION
Addresses https://github.com/thp/urlwatch/issues/353