### PR TITLE
Import pycodestyle in the relevant test to make it easier to skip

### DIFF
--- a/lib/urlwatch/tests/test_handler.py
+++ b/lib/urlwatch/tests/test_handler.py
@@ -1,7 +1,6 @@
 import sys
 from glob import glob
 
-import pycodestyle as pycodestyle
 from urlwatch.jobs import UrlJob, JobBase, ShellJob
 from urlwatch.storage import UrlsYaml, UrlsTxt
 
@@ -80,6 +79,7 @@ def test_load_hooks_py():
 
 def test_pep8_conformance():
     """Test that we conform to PEP-8."""
+    import pycodestyle
     style = pycodestyle.StyleGuide(ignore=['E501', 'E402', 'W503'])
 
     py_files = [y for x in os.walk(os.path.abspath('.')) for y in glob(os.path.join(x[0], '*.py'))]


### PR DESCRIPTION
Hi,
This test is not relevant to distros which run tests, they should be able to skip it easily and avoid installing pycodestyle.