### PR TITLE
Some Matrix reporter improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,31 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 ## [UNRELEASED]
 
+### Added
+
+- The Markdown reporter now supports limiting the report length via the
+  `max_length` parameter of the `submit` method. The length limiting logic is
+  smart in the sense that it will try trimming the details first, followed by
+  omitting them completely, followed by omitting the summary. If a part of the
+  report is omitted, a note about this is added to the report. (PR#572, by
+  Denis Kasak)
+
 ### Changed
 
 - Diff output is now generated more uniformly, independent of whether
   the input data has a trailing newline or not; if this behavior is not
   intended, use an external `diff_tool` (PR#550, by Adam Goldsmith)
+
+- The Matrix reporter was improved in several ways (PR#572, by Denis Kasak):
+
+  - The maximum length of the report was increase from 4096 to 16384.
+  - The report length limiting is now implemented via the new length limiting
+    functionality of the Markdown reporter. Previously, the report was simply
+    trimmed at the end which could break the diff blocks and make them render
+    incorrectly.
+  - The diff code blocks are now tagged as diffs which will allow the diffs to
+    be syntax highlighted as such. This doesn't yet work in Element, pending on
+    the resolution of trentm/python-markdown2#370.
 
 ## [2.21] -- 2020-07-31
 

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -731,12 +731,12 @@ class MarkdownReporter(ReporterBase):
         trim_message_length = len(trim_message)
 
         if max_length is None or len(s) + wrapper_length <= max_length:
-            return "```\n{}\n```".format(s)
+            return "```diff\n{}\n```".format(s)
         else:
             while len(s) + wrapper_length + trim_message_length > max_length:
                 s = re.sub("\n.*$", "", s)
 
-            return "```\n{}\n```\n{}".format(s, trim_message)
+            return "```diff\n{}\n```\n{}".format(s, trim_message)
 
     def _format_content(self, job_state):
         if job_state.verb == 'error':
@@ -794,7 +794,7 @@ class MatrixReporter(MarkdownReporter):
         client_api = matrix_client.api.MatrixHttpApi(homeserver_url, access_token)
 
         if Markdown is not None:
-            body_html = Markdown(extras=["fenced-code-blocks"]).convert(body_markdown)
+            body_html = Markdown(extras=["fenced-code-blocks", "highlightjs-lang"]).convert(body_markdown)
 
             client_api.send_message_event(
                 room_id,

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -742,7 +742,7 @@ class MatrixReporter(MarkdownReporter):
         client_api = matrix_client.api.MatrixHttpApi(homeserver_url, access_token)
 
         if Markdown is not None:
-            body_html = Markdown().convert(body_markdown)
+            body_html = Markdown(extras=["fenced-code-blocks"]).convert(body_markdown)
 
             client_api.send_message_event(
                 room_id,

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -731,8 +731,13 @@ class MarkdownReporter(ReporterBase):
         if max_length is None or len(s) + wrapper_length <= max_length:
             return "```diff\n{}\n```".format(s)
         else:
-            while len(s) + wrapper_length + trim_message_length > max_length:
+            while len(s) + wrapper_length + trim_message_length > max_length and '\n' in s:
                 s = re.sub("\n.*$", "", s)
+
+            # If it's still longer than the max length, we have a single long
+            # line left so just cut it short.
+            if len(s) + wrapper_length + trim_message_length > max_length:
+                s = s[:max_length]
 
             return "```diff\n{}\n```\n{}".format(s, trim_message)
 

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -722,9 +722,7 @@ class MarkdownReporter(ReporterBase):
 
     @staticmethod
     def _format_details_body(s, max_length):
-        # Number of characters for the Markdown code block wrapper (three
-        # backticks and a newline, twice).
-        wrapper_length = 8
+        wrapper_length = len("```diff\n\n```")
 
         # Message to print when the diff is too long.
         trim_message = "[... diff trimmed ...]"

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -702,8 +702,8 @@ class MarkdownReporter(ReporterBase):
         if summary and show_footer:
             yield from footer
 
-    @staticmethod
-    def _render(max_length, summary=None, details=None, footer=None):
+    @classmethod
+    def _render(cls, max_length, summary=None, details=None, footer=None):
         """Render the report components, trimming them if the available length is insufficient.
 
         Returns a tuple (trimmed, summary, details, footer).
@@ -760,7 +760,7 @@ class MarkdownReporter(ReporterBase):
                         # Calculate the available length for the body and render it
                         avail_length = body_len_per_details - 1
 
-                        body_trimmed, body = MarkdownReporter._format_details_body(body, avail_length)
+                        body_trimmed, body = cls._format_details_body(body, avail_length)
 
                         if body_trimmed:
                             details_trimmed = True

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -773,7 +773,7 @@ class MarkdownReporter(ReporterBase):
 
 class MatrixReporter(MarkdownReporter):
     """Send a message to a room using the Matrix protocol"""
-    MAX_LENGTH = 4096
+    MAX_LENGTH = 16384
 
     __kind__ = 'matrix'
 


### PR DESCRIPTION
This includes:

- Smarter logic for report trimming (to meet the maximum length requirement) so
  we don't end up with invalid Markdown.
- Proper rendering when a code block starts with empty lines.
- Preparation for syntax highlighting for diffs (pending on a resolution of an
  [upstream issue](https://github.com/trentm/python-markdown2/issues/370)).
- Increase in message max length.