### PR TITLE
feat(UrlJob): add url_for_human option

### DIFF
--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -46,6 +46,7 @@ Job-specific optional keys:
 - ``ignore_http_error_codes``: List of HTTP errors to ignore (see :ref:`advanced_topics`)
 - ``ignore_timeout_errors``: Do not report errors when the timeout is hit
 - ``ignore_too_many_redirects``: Ignore redirect loops (see :ref:`advanced_topics`)
+- ``url_for_human``: The URL in report for human read
 
 (Note: ``url`` implies ``kind: url``)
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -221,13 +221,13 @@ class UrlJob(Job):
     __required__ = ('url',)
     __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
                     'headers', 'ignore_connection_errors', 'ignore_http_error_codes', 'encoding', 'timeout',
-                    'ignore_timeout_errors', 'ignore_too_many_redirects')
+                    'ignore_timeout_errors', 'ignore_too_many_redirects', 'url_for_human')
 
     LOCATION_IS_URL = True
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 
     def get_location(self):
-        return self.url
+        return self.url_for_human if self.url_for_human else self.url
 
     def retrieve(self, job_state):
         headers = {


### PR DESCRIPTION
when url is api, use url_for_human in report, so click the link in report will show the content that we want.