### PR TITLE
Update version check for python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ main_py = open(os.path.join('lib', 'urlwatch', '__init__.py')).read()
 m = dict(re.findall("\n__([a-z]+)__ = '([^']+)'", main_py))
 docs = re.findall('"""(.*?)"""', main_py, re.DOTALL)
 
-if sys.version_info < (3, 3):
-    sys.exit('urlwatch requires Python 3.3 or newer')
+if sys.version_info < (3, 5):
+    sys.exit('urlwatch requires Python 3.5 or newer')
 
 m['name'] = 'urlwatch'
 m['author'], m['author_email'] = re.match(r'(.*) <(.*)>', m['author']).groups()


### PR DESCRIPTION
https://github.com/thp/urlwatch/blob/dfc5751bf3e42e0718b60c9aa0f5188f6c93c6bf/setup.py#L25
Updated Python dependency was declared as 3.5, but the version check still warns only for version < 3.3
This commit fixes it