### PR TITLE
fix filter bug

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -82,7 +82,8 @@ class FilterBase(object, metaclass=TrackSubClasses):
             filter_instance = filtercls(state.job, state)
             if filter_instance.match():
                 logger.info('Auto-applying filter %r to %s', filter_instance, state.job.get_location())
-                data = filter_instance.filter(data)
+                # filters require a subfilter argument
+                data = filter_instance.filter(data, None)
 
         return data
 


### PR DESCRIPTION
Fix crash:

```
Traceback (most recent call last):
  File "/home/martin/.local/lib/python3.5/site-packages/urlwatch/handler.py", line 88, in process
    data = FilterBase.auto_process(self, data)
  File "/home/martin/.local/lib/python3.5/site-packages/urlwatch/filters.py", line 84, in auto_process
    data = filter_instance.filter(data)
TypeError: filter() missing 1 required positional argument: 'subfilter'

```