### PR TITLE
Add options that require an argument as separate list elements

### DIFF
--- a/lib/urlwatch/html2txt.py
+++ b/lib/urlwatch/html2txt.py
@@ -98,7 +98,7 @@ def html2text(data, baseurl, method, options):
 
     for k, v in options.items():
         if v is not None:
-            cmd.append('-{} {}'.format(k, v))
+            cmd.extend(['-{}'.format(k), '{}'.format(v)])
         else:
             cmd.append('-{}'.format(k))
 


### PR DESCRIPTION
When building a command argument list for subprocess.Popen(), add
options that require an argument as separate list elements. This results
in a list like this:

2021-02-05 12:33:37,880 html2txt DEBUG: Command: ['html2text', '-nobs', '-utf8', '-width', '132'], stdout encoding: utf-8

instead of:

2021-02-05 12:33:37,880 html2txt DEBUG: Command: ['html2text', '-nobs', '-utf8', '-width 132'], stdout encoding: utf-8

which produces a CLI options parsing error because there is no option
called '-width 132'.

Resolves #618 