### PR TITLE
add command line argument to specify which jobs will be run

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -312,3 +312,14 @@ the URLs, like this:
     filter:
       - grep: "Thing B"
 
+
+Running a subset of jobs
+------------------------
+
+To run one or more specific jobs instead of all known jobs, provide
+the job index numbers to the urlwatch command. For example, to run
+jobs with index 2, 4, and 7:
+
+.. code-block:: bash
+
+   urlwatch 2 4 7

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -7,7 +7,9 @@ Jobs are the kind of things that `urlwatch` can monitor.
 
 The list of jobs to run are contained in the configuration file ``urls.yaml``,
 accessed with the command ``urlwatch --edit``, each separated by a line
-containing only ``---``.
+containing only ``---``. The command ``urlwatch --list`` prints the name
+of each job, along with its index number (1,2,3,...) which gets assigned
+automatically according to its position in the configuration file.
 
 While optional, it is recommended that each job starts with a ``name`` entry:
 

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -75,6 +75,7 @@ class CommandConfig(BaseConfig):
 
         parser = argparse.ArgumentParser(description=urlwatch.__doc__,
                                          formatter_class=argparse.RawDescriptionHelpFormatter)
+        parser.add_argument('joblist', metavar='JOB', type=int, nargs="*", help='index of job(s) to run, as numbered according to the --list command. If none specified, then all jobs will be run.')
         parser.add_argument('--version', action='version', version='%(prog)s {}'.format(urlwatch.__version__))
         parser.add_argument('-v', '--verbose', action='store_true', help='show debug output')
         group = parser.add_argument_group('files and directories')

--- a/lib/urlwatch/tests/test_handler.py
+++ b/lib/urlwatch/tests/test_handler.py
@@ -11,7 +11,7 @@ import tempfile
 import os
 
 from urlwatch import storage
-from urlwatch.config import BaseConfig
+from urlwatch.config import CommandConfig
 from urlwatch.storage import YamlConfigStorage, CacheMiniDBStorage
 from urlwatch.main import Urlwatch
 from urlwatch.util import import_module_from_source
@@ -87,12 +87,10 @@ def test_pep8_conformance():
     assert result.total_errors == 0, "Found #{0} code style errors".format(result.total_errors)
 
 
-class ConfigForTest(BaseConfig):
+class ConfigForTest(CommandConfig):
     def __init__(self, config, urls, cache, hooks, verbose):
         (prefix, bindir) = os.path.split(os.path.dirname(os.path.abspath(sys.argv[0])))
-        super().__init__('urlwatch', os.path.dirname(__file__), config, urls, cache, hooks, verbose)
-        self.edit = False
-        self.edit_hooks = False
+        super().__init__('urlwatch', os.path.dirname(__file__), bindir, prefix, config, urls, hooks, cache, verbose)
 
 
 @contextlib.contextmanager

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -53,10 +53,10 @@ def run_parallel(func, items):
 def run_jobs(urlwatcher):
     cache_storage = urlwatcher.cache_storage
     jobs = [job.with_defaults(urlwatcher.config_storage.config)
-            for job in urlwatcher.jobs]
+            for (idx,job) in enumerate(urlwatcher.jobs) if ((idx+1) in urlwatcher.urlwatch_config.joblist or (len(urlwatcher.urlwatch_config.joblist) == 0))]
     report = urlwatcher.report
 
-    logger.debug('Processing %d jobs', len(jobs))
+    logger.debug('Processing %d jobs (out of %d)', len(jobs), len(urlwatcher.jobs))
     with contextlib.ExitStack() as exit_stack:
         for job_state in run_parallel(lambda job_state: job_state.process(),
                                       (exit_stack.enter_context(JobState(cache_storage, job)) for job in jobs)):

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -53,7 +53,7 @@ def run_parallel(func, items):
 def run_jobs(urlwatcher):
     cache_storage = urlwatcher.cache_storage
     jobs = [job.with_defaults(urlwatcher.config_storage.config)
-            for (idx,job) in enumerate(urlwatcher.jobs) if ((idx+1) in urlwatcher.urlwatch_config.joblist or (len(urlwatcher.urlwatch_config.joblist) == 0))]
+            for (idx, job) in enumerate(urlwatcher.jobs) if ((idx + 1) in urlwatcher.urlwatch_config.joblist or (len(urlwatcher.urlwatch_config.joblist) == 0))]
     report = urlwatcher.report
 
     logger.debug('Processing %d jobs (out of %d)', len(jobs), len(urlwatcher.jobs))

--- a/lib/urlwatch/worker.py
+++ b/lib/urlwatch/worker.py
@@ -51,9 +51,11 @@ def run_parallel(func, items):
 
 
 def run_jobs(urlwatcher):
+    if not all(1 <= idx <= len(urlwatcher.jobs) for idx in urlwatcher.urlwatch_config.joblist):
+        raise ValueError(f'All job indices must be between 1 and {len(urlwatcher.jobs)}: {urlwatcher.urlwatch_config.joblist}')
     cache_storage = urlwatcher.cache_storage
     jobs = [job.with_defaults(urlwatcher.config_storage.config)
-            for (idx, job) in enumerate(urlwatcher.jobs) if ((idx + 1) in urlwatcher.urlwatch_config.joblist or (len(urlwatcher.urlwatch_config.joblist) == 0))]
+            for (idx, job) in enumerate(urlwatcher.jobs) if ((idx + 1) in urlwatcher.urlwatch_config.joblist or (not urlwatcher.urlwatch_config.joblist))]
     report = urlwatcher.report
 
     logger.debug('Processing %d jobs (out of %d)', len(jobs), len(urlwatcher.jobs))


### PR DESCRIPTION
Hi Thomas- this is a simple change that might be useful in situations where some jobs should be run at different intervals. For example, if only jobs 2,4,and 6 should be run hourly and all the rest should run once per day, then this pair of crontab lines would do that:

05 0-2,4-23   * * * /home/pi/.local/bin/urlwatch 2 4 6
05 3   * * * /home/pi/.local/bin/urlwatch

For small sets of jobs, this could be an adequate solution for the use cases described in issues #148 #171 #331 .