### PR TITLE
Add option for browser jobs to disable Chromium sandbox

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -272,6 +272,12 @@ before a page is considered loaded by using the `wait_until` option. It can take
   - `networkidle2` will wait until there are no more than 2 network connections for at least 500 ms.
 
 
+Disabling Chromium's sandbox
+----------------------------
+
+For browser jobs, you can disable the Chromium sandbox to isolate processes. BEWARE: This is a less secure method of loading web pages and should be used carefully. See https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/design/sandbox.md for details.
+
+
 Treating ``NEW`` jobs as ``CHANGED``
 ------------------------------------
 

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -85,6 +85,8 @@ Job-specific optional keys:
 
 - ``wait_until``:  Either ``load``, ``domcontentloaded``, ``networkidle0``, or ``networkidle2`` (see :ref:`advanced_topics`)
 
+- ``no_sandbox``:  Do not use Chromium sandbox (true/false) (see :ref:`advanced_topics`)
+
 
 As this job uses `Pyppeteer <https://github.com/pyppeteer/pyppeteer>`__
 to render the page in a headless Chromium instance, it requires massively

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -364,7 +364,7 @@ class BrowserJob(Job):
 
     __required__ = ('navigate',)
 
-    __optional__ = ('wait_until',)
+    __optional__ = ('wait_until','no_sandbox',)
 
     LOCATION_IS_URL = True
 
@@ -373,7 +373,7 @@ class BrowserJob(Job):
 
     def main_thread_enter(self):
         from .browser import BrowserContext
-        self.ctx = BrowserContext()
+        self.ctx = BrowserContext(no_sandbox=self.no_sandbox)
 
     def main_thread_exit(self):
         self.ctx.close()

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -364,7 +364,7 @@ class BrowserJob(Job):
 
     __required__ = ('navigate',)
 
-    __optional__ = ('wait_until','no_sandbox',)
+    __optional__ = ('wait_until', 'no_sandbox',)
 
     LOCATION_IS_URL = True
 


### PR DESCRIPTION
I was getting errors when running a browser job which were fixed by adding the "--no-sandbox" option for Chromium. This pull requests adds support for this option in the yaml browser job definition.

This was mentioned in an early message as part of the discuss for issue #555 but I don't know if it is still relevant.