### PR TITLE
enable user_visible_url for command/shell jobs

### DIFF
--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -48,7 +48,6 @@ Job-specific optional keys:
 - ``ignore_http_error_codes``: List of HTTP errors to ignore (see :ref:`advanced_topics`)
 - ``ignore_timeout_errors``: Do not report errors when the timeout is hit
 - ``ignore_too_many_redirects``: Ignore redirect loops (see :ref:`advanced_topics`)
-- ``user_visible_url``: Different URL to show in reports (e.g. when watched URL is a REST API URL, and you want to show a webpage)
 
 (Note: ``url`` implies ``kind: url``)
 
@@ -132,6 +131,7 @@ Optional keys for all job types
 - ``treat_new_as_changed``: Will treat jobs that don't have any historic data as ``CHANGED`` instead of ``NEW`` (and create a diff for new jobs)
 - ``compared_versions``: Number of versions to compare for similarity
 - ``kind`` (redundant): Either ``url``, ``shell`` or ``browser``.  Automatically derived from the unique key (``url``, ``command`` or ``navigate``) of the job type
+- ``user_visible_url``: Different URL to show in reports (e.g. when watched URL is a REST API URL, and you want to show a webpage)
 
 
 Settings keys for all jobs at once

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -180,10 +180,11 @@ class JobBase(object, metaclass=TrackSubClasses):
 
 class Job(JobBase):
     __required__ = ()
-    __optional__ = ('name', 'filter', 'max_tries', 'diff_tool', 'compared_versions', 'diff_filter', 'treat_new_as_changed')
+    __optional__ = ('name', 'filter', 'max_tries', 'diff_tool', 'compared_versions', 'diff_filter', 'treat_new_as_changed', 'user_visible_url')
 
     # determine if hyperlink "a" tag is used in HtmlReporter
-    LOCATION_IS_URL = False
+    def location_is_url(self):
+        return re.match("^([a-zA-Z0-9+.-]+)://", self.get_location())
 
     def pretty_name(self):
         return self.name if self.name else self.get_location()
@@ -198,7 +199,7 @@ class ShellJob(Job):
     __optional__ = ()
 
     def get_location(self):
-        return self.command
+        return self.user_visible_url or self.command
 
     def retrieve(self, job_state):
         process = subprocess.Popen(self.command, stdout=subprocess.PIPE, shell=True)
@@ -221,9 +222,8 @@ class UrlJob(Job):
     __required__ = ('url',)
     __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
                     'headers', 'ignore_connection_errors', 'ignore_http_error_codes', 'encoding', 'timeout',
-                    'ignore_timeout_errors', 'ignore_too_many_redirects', 'user_visible_url')
+                    'ignore_timeout_errors', 'ignore_too_many_redirects')
 
-    LOCATION_IS_URL = True
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 
     def get_location(self):
@@ -366,10 +366,8 @@ class BrowserJob(Job):
 
     __optional__ = ('wait_until',)
 
-    LOCATION_IS_URL = True
-
     def get_location(self):
-        return self.navigate
+        return self.user_visible_url or self.navigate
 
     def main_thread_enter(self):
         from .browser import BrowserContext

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -183,7 +183,7 @@ class HtmlReporter(ReporterBase):
         for job_state in self.report.get_filtered_job_states(self.job_states):
             job = job_state.job
 
-            if job.LOCATION_IS_URL:
+            if job.location_is_url():
                 title = '<a href="{location}">{pretty_name}</a>'
             elif job.pretty_name() != job.get_location():
                 title = '<span title="{location}">{pretty_name}</span>'


### PR DESCRIPTION
hi there. would really love to be able to do this for command/shell jobs. 

I have lots of jobs that are cumbersome to get via default url job because of special cookie setup or websocket connections etc. , so I put them in .sh scripts and run them as command jobs. However I cant make clickable url in my HtmlReporter.

The only thing I'm a bit puzzled about is `LOCATION_IS_URL` which should really be a function ?

