### PR TITLE
Ensure code block starts with newline

### DIFF
--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -111,6 +111,7 @@ with no sounds, and monospace formatted (``monospace``).
 By default notifications are not silent and no formatting is done.
 
 .. code:: yaml
+
    telegram:
      # ...
      silent: true # message is sent silently


### PR DESCRIPTION
Code blocks are not visible if not started with a newline. This can be verified using the Github Preview function as well as in the current (2021-08-27T20:18+02:00) [documentation](https://urlwatch.readthedocs.io/en/latest/reporters.html#telegram)