### PR TITLE
Fix "ResourceWarning: unclosed file" warnings

### DIFF
--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -268,7 +268,8 @@ class UrlJob(Job):
         file_scheme = 'file://'
         if self.url.startswith(file_scheme):
             logger.info('Using local filesystem (%s URI scheme)', file_scheme)
-            return open(self.url[len(file_scheme):], 'rt').read()
+            with open(self.url[len(file_scheme):], 'rt') as f:
+                return f.read()
 
         if self.headers:
             self.add_custom_headers(headers)

--- a/lib/urlwatch/tests/test_filter_documentation.py
+++ b/lib/urlwatch/tests/test_filter_documentation.py
@@ -39,7 +39,8 @@ class YAMLCodeBlockVisitor(docutils.nodes.NodeVisitor):
 
 
 def load_filter_testdata():
-    doc = parse_rst(open(os.path.join(root, 'docs/source/filters.rst')).read())
+    with open(os.path.join(root, 'docs/source/filters.rst')) as f:
+        doc = parse_rst(f.read())
     visitor = YAMLCodeBlockVisitor(doc)
     doc.walk(visitor)
 
@@ -56,10 +57,12 @@ FILTER_DOC_URLS = load_filter_testdata()
 
 @pytest.mark.parametrize('url, job', FILTER_DOC_URLS.items())
 def test_url(url, job):
-    testdata = yaml.safe_load(open(os.path.join(here, 'data/filter_documentation_testdata.yaml')).read())
+    with open(os.path.join(here, 'data/filter_documentation_testdata.yaml')) as f:
+        testdata = yaml.safe_load(f)
     d = testdata[url]
     if 'filename' in d:
-        input_data = open(os.path.join(here, 'data', d['filename']), 'rb').read()
+        with open(os.path.join(here, 'data', d['filename']), 'rb') as f:
+            input_data = f.read()
     else:
         input_data = d['input']
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ import os
 import re
 import sys
 
-main_py = open(os.path.join('lib', 'urlwatch', '__init__.py')).read()
+with open(os.path.join('lib', 'urlwatch', '__init__.py')) as f:
+    main_py = f.read()
 m = dict(re.findall("\n__([a-z]+)__ = '([^']+)'", main_py))
 docs = re.findall('"""(.*?)"""', main_py, re.DOTALL)
 


### PR DESCRIPTION
* Use context managers instead of open(path).read().
* PyYAML can directly load file-like object.

This fixes (amongst others):
```
=================================================== warnings summary ===================================================
lib/urlwatch/tests/test_filter_documentation.py:42                                                                                                                                                                 
  /var/tmp/portage/www-misc/urlwatch-2.24/work/urlwatch-2.24/lib/urlwatch/tests/test_filter_documentation.py:42: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/tmp/portage/www-misc/urlwatch-2.24/work/urlwatch-2.24/lib/urlwatch/tests/../../../docs/source/filters.rst' mode='r' encoding='UTF-8'>                                                                                                                   
    doc = parse_rst(open(os.path.join(root, 'docs/source/filters.rst')).read())                                                                                                                                    
                                                                                                                                                                                                                   
lib/urlwatch/tests/test_filters.py:39                                                                                                                                                                              
  /var/tmp/portage/www-misc/urlwatch-2.24/work/urlwatch-2.24/lib/urlwatch/tests/test_filters.py:39: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/tmp/portage/www-misc/urlwatch-2.24/work/urlwatch-2.24/lib/urlwatch/tests/data/filter_tests.yaml' mode='r' encoding='utf8'>                                                                                                                                           
    FILTER_TESTS = yaml.safe_load(open(os.path.join(os.path.dirname(__file__), 'data/filter_tests.yaml'), 'r', encoding='utf8'))
                                                                                                                                                                                                                   
lib/urlwatch/tests/test_filter_documentation.py: 27 warnings                                                                                                                                                       
  /var/tmp/portage/www-misc/urlwatch-2.24/work/urlwatch-2.24/lib/urlwatch/tests/test_filter_documentation.py:59: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/tmp/portage/www-misc/urlwatch-2.24/work/urlwatch-2.24/lib/urlwatch/tests/data/filter_documentation_testdata.yaml' mode='r' encoding='UTF-8'>                                                                                                            
    testdata = yaml.safe_load(open(os.path.join(here, 'data/filter_documentation_testdata.yaml')).read())              
```