### PR TITLE
Enable colors in Discord reporter using code section with diff syntax

### DIFF
--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -183,12 +183,14 @@ is a sample configuration:
       webhook_url: 'https://discordapp.com/api/webhooks/11111XXXXXXXXXXX/BBBBYYYYYYYYYYYYYYYYYYYYYYYyyyYYYYYYYYYYYYYY'
       enabled: true
       embed: true
+      colored: true
       subject: '{count} changes: {jobs}'
 
 To set up Discord, from your Discord Server settings, select Integration and then create a "New Webhook", give the webhook a name to post under, select a channel, push "Copy Webhook URL" and paste it into the configuration as seen above.
 
-Embedded content might be easier to read and identify individual reports. subject preceeds the embedded report and is only used when embed is true.
+Embedded content might be easier to read and identify individual reports. Subject preceeds the embedded report and is only used when `embed` is true.
 
+When `colored` is true reports will be embedded in code section (with diff syntax) to enable colors.
 
 IFTTT
 -----

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -711,6 +711,9 @@ class DiscordReporter(TextReporter):
         return result
 
     def submit_to_discord(self, webhook_url, text):
+        if self.config.get('colored', True):
+            text = "```diff\n" + text + "```"
+
         if self.config.get('embed', False):
             filtered_job_states = list(self.report.get_filtered_job_states(self.job_states))
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -142,6 +142,7 @@ DEFAULT_CONFIG = {
         'discord': {
             'enabled': False,
             'embed': False,
+            'colored': True,
             'subject': '{count} changes: {jobs}',
             'webhook_url': '',
             'max_message_length': 2000,


### PR DESCRIPTION
Discord allows to color messages using a code section with diff syntax: https://www.writebots.com/discord-text-formatting/#How_to_Color_Text_RED_in_Discord

 I added this functionality in the code.