### PR TITLE
Add strip lines filter

### DIFF
--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -71,6 +71,7 @@ At the moment, the following filters are built-in:
 - **sort**: Sort input items
 - **remove-duplicate-lines**: Remove duplicate lines (case sensitive)
 - **strip**: Strip leading and trailing whitespace
+- **striplines**: Strip leading and trailing whitespace in each line
 - **xpath**: Filter XML/HTML using XPath expressions
 - **jq**: Filter, transform and extract values from JSON
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -40,7 +40,7 @@ Finally, you often use the ``filter`` key to select one or more :ref:`filters` t
 - make iCal more readable: ``ical2text``
 - make binary readable: ``hexdump``
 - just detect changes: ``sha1sum``
-- edit text: ``grep``, ``grepi``, ``strip``, ``sort``
+- edit text: ``grep``, ``grepi``, ``strip``, ``sort``, ``striplines``
 
 These :ref:`filters` can be chained. As an example, after retrieving an HTML document by using the ``url`` key, you can extract a selection with the ``xpath`` filter, convert this to text with ``html2text``, use ``grep`` to extract only lines matching a specific regular expression, and then ``sort`` them:
 

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -496,6 +496,17 @@ class StripFilter(FilterBase):
         return data.strip()
 
 
+class StripLinesFilter(FilterBase):
+    """Strip leading and trailing whitespace in every line"""
+
+    __kind__ = 'striplines'
+
+    __no_subfilter__ = True
+
+    def filter(self, data, subfilter=None):
+        return '\n'.join(line.strip() for line in data.splitlines())
+
+
 class FilterBy(Enum):
     ATTRIBUTE = 1
     TAG = 2

--- a/lib/urlwatch/tests/data/filter_tests.yaml
+++ b/lib/urlwatch/tests/data/filter_tests.yaml
@@ -326,3 +326,11 @@ re_sub_multiline:
     One Line
     
     Another Line
+strip:
+  filter: strip
+  data: "  The rose is red;   \n\nthe violet's blue.\nSugar is sweet,       \nand so are you.   "
+  expected_result: "The rose is red;   \n\nthe violet's blue.\nSugar is sweet,       \nand so are you."
+striplines:
+  filter: striplines
+  data: "  The rose is red;   \n\nthe violet's blue.\nSugar is sweet,       \nand so are you.   "
+  expected_result: "The rose is red;\n\nthe violet's blue.\nSugar is sweet,\nand so are you."


### PR DESCRIPTION
This PR adds a strip lines filter which is similar to the existing `strip` filter. The difference is that it strips every line in the output and not only the beginning and the end of the output.