### PR TITLE
Support change of useragent for Browser job

### DIFF
--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -95,7 +95,7 @@ Required keys:
 Job-specific optional keys:
 
 - ``wait_until``:  Either ``load``, ``domcontentloaded``, ``networkidle0``, or ``networkidle2`` (see :ref:`advanced_topics`)
-
+- ``useragent``:  Change useragent (will be passed to pyppeteer)
 
 As this job uses `Pyppeteer <https://github.com/pyppeteer/pyppeteer>`__
 to render the page in a headless Chromium instance, it requires massively

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -397,7 +397,7 @@ class BrowserJob(Job):
 
     __required__ = ('navigate',)
 
-    __optional__ = ('wait_until',)
+    __optional__ = ('wait_until', 'useragent')
 
     def get_location(self):
         return self.user_visible_url or self.navigate
@@ -410,4 +410,4 @@ class BrowserJob(Job):
         self.ctx.close()
 
     def retrieve(self, job_state):
-        return self.ctx.process(self.navigate, wait_until=self.wait_until)
+        return self.ctx.process(self.navigate, wait_until=self.wait_until, useragent=self.useragent)


### PR DESCRIPTION
This should solve issue #670 

Please check/modify as you like.

- Added optional key "useragent"
- Using it to set the useragent for pyppeteer
- Added description of key in documentation
  (the option is still missing in the man pages though)