### PR TITLE
WIP: Add RSS Reporter with feedgen

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -46,6 +46,8 @@ from .mailer import SendmailMailer
 from .util import TrackSubClasses, chunkstring
 from .xmpp import XMPP
 
+from feedgen.feed import FeedGenerator
+
 try:
     import chump
 except ImportError:

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -385,6 +385,35 @@ class StdoutReporter(TextReporter):
                 print(line)
 
 
+class RssReporter(TextReporter):
+    """Print summary on stdout (the console) as RSS"""
+
+    __kind__ = 'rss'
+
+    def submit(self):
+
+        body = '\n'.join(super().submit())
+        if not body:
+            return
+        
+        # Text output within preformatted tag.
+        body = '<pre>' + body + '</pre>'
+
+        # Create feed.
+        fg = FeedGenerator()
+        fg.title(self.config['feed']['title'])
+        fg.link( href=self.config['feed']['url'], rel='alternate' )
+        fg.subtitle(self.config['feed']['subtitle'])
+
+        # Create feed item
+        fe = fg.add_entry()
+        fe.title('New changes')
+        fe.content(body, type='CDATA')
+
+        # Output feed to STDOUT.
+        rss = fg.rss_str().decode("utf-8")
+        print(rss)
+
 class EMailReporter(TextReporter):
     """Send summary via e-mail / SMTP"""
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -92,6 +92,15 @@ DEFAULT_CONFIG = {
             'color': True,
         },
 
+        'rss': {
+            'enabled': False,
+            'feed': {
+                'title': 'urlwatch',
+                'subtitle': 'Changes in my monitored URLs.',
+                'url': 'http://example.com',
+            },
+        },
+
         'email': {
             'enabled': False,
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ keyring
 appdirs
 lxml
 cssselect
+feedgen


### PR DESCRIPTION
Hello, because needing it myself, I've picked up the work on the RSS reporter (#553, #76, #53). I tried a very basic approach: Simply take the STDOUT output and wrap it into an RSS feed with 1 item.

Here's [https://jaehnig.org/urlwatch/rss.xml an example output].

If `urlwatch` now runs e.g. once a day, then in my feedreader I get this new item once per day. When using on online feed reader like Feedly, the old entries get saved by Feedly anyway.

Create different feeds for different jobs should also be possible via

    urlwatch 1 > 1.xml
    urlwatch 2 > 2.xml

I think this is very much "good enough", much better than no RSS feed at all. But of course I'm happy to polish this up if there are some low-hanging fruits. :)