### PR TITLE
reporters: report jobs separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - `browser` job: Add support for specifying `useragent` (#700, by Francesco Versaci)
 - Document how to ignore whitespace changes (PR#707, by Paulo Magalhaes)
 - `shell` reporter: Call a script or program when chanegs are detected (fixes #650)
+- New `separate` configuration option for reporters to split reports into one-per-job (contributed by Ryne Everett)
 
 ### Changed
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -88,6 +88,7 @@ output in color, as well as HTML e-mail using ``sendmail``:
        line_length: 75
      html:
        diff: unified
+       separate: true
      email:
        enabled: true
        method: sendmail
@@ -108,6 +109,9 @@ Configuration settings like ``text``, ``html`` and ``markdown`` will
 apply to all reporters that derive from that reporter (for example,
 the ``stdout`` reporter uses ``text``, while the ``email`` reporter
 with ``html: true`` set uses ``html``).
+
+Setting ``separate: true`` will cause the reporter to send a report for
+each job rather than a combined report for all jobs.
 
 .. _job_defaults:
 

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -109,6 +109,10 @@ class ReporterBase(object, metaclass=TrackSubClasses):
         return othercls(self.report, config, self.job_states, self.duration)
 
     @classmethod
+    def get_base_config(cls, report):
+        return report.config['report'][cls.mro()[-3].__kind__]
+
+    @classmethod
     def reporter_documentation(cls):
         result = []
         for sc in TrackSubClasses.sorted_by_kind(cls):
@@ -134,7 +138,12 @@ class ReporterBase(object, metaclass=TrackSubClasses):
             if cfg['enabled']:
                 any_enabled = True
                 logger.info('Submitting with %s (%r)', name, subclass)
-                subclass(report, cfg, job_states, duration).submit()
+                base_config = subclass.get_base_config(report)
+                if base_config.get('separate', False):
+                    for job_state in job_states:
+                        subclass(report, cfg, [job_state], duration).submit()
+                else:
+                    subclass(report, cfg, job_states, duration).submit()
 
         if not any_enabled:
             logger.warning('No reporters enabled.')
@@ -156,11 +165,14 @@ class SafeHtml(object):
 
 
 class HtmlReporter(ReporterBase):
+
+    __kind__ = 'html'
+
     def submit(self):
         yield from (str(part) for part in self._parts())
 
     def _parts(self):
-        cfg = self.report.config['report']['html']
+        cfg = self.get_base_config(self.report)
 
         yield SafeHtml("""<!DOCTYPE html>
         <html><head>
@@ -262,8 +274,11 @@ class HtmlReporter(ReporterBase):
 
 
 class TextReporter(ReporterBase):
+
+    __kind__ = 'text'
+
     def submit(self):
-        cfg = self.report.config['report']['text']
+        cfg = self.get_base_config(self.report)
         line_length = cfg['line_length']
         show_details = cfg['details']
         show_footer = cfg['footer']
@@ -370,7 +385,7 @@ class StdoutReporter(TextReporter):
     def submit(self):
         print = self._get_print()
 
-        cfg = self.report.config['report']['text']
+        cfg = self.get_base_config(self.report)
         line_length = cfg['line_length']
 
         separators = (line_length * '=', line_length * '-', '-- ') if line_length else ()
@@ -763,8 +778,11 @@ class DiscordReporter(TextReporter):
 
 
 class MarkdownReporter(ReporterBase):
+
+    __kind__ = 'markdown'
+
     def submit(self, max_length=None):
-        cfg = self.report.config['report']['markdown']
+        cfg = self.get_base_config(self.report)
         show_details = cfg['details']
         show_footer = cfg['footer']
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -75,16 +75,19 @@ DEFAULT_CONFIG = {
             'details': True,
             'footer': True,
             'minimal': False,
+            'separate': False,
         },
 
         'markdown': {
             'details': True,
             'footer': True,
             'minimal': False,
+            'separate': False,
         },
 
         'html': {
             'diff': 'unified',  # "unified" or "table"
+            'separate': False,
         },
 
         'stdout': {


### PR DESCRIPTION
Adapted from https://github.com/thp/urlwatch/pull/305.

I made some adjustments per the review comment:

>     2. The `separate` key is nowhere documented or put into the example config, also please rethink where we place the separate key -- should it be per-reporter or a global config?

Is this what you had in mind?