### PR TITLE
Avoids deleting 'method' key from shared subfilter

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -321,8 +321,7 @@ class Html2TextFilter(FilterBase):
     def filter(self, data, subfilter):
         if 'method' in subfilter:
             method = subfilter['method']
-            del subfilter['method']
-            options = subfilter
+            options = {key: val for (key, val) in subfilter.items() if key != 'method'}
         else:
             method = 're'
             options = {}

--- a/lib/urlwatch/tests/test_filters.py
+++ b/lib/urlwatch/tests/test_filters.py
@@ -89,3 +89,13 @@ def test_shellpipe_inherits_environment_but_does_not_modify_it():
 
     # Check that outside the variable wasn't overwritten by the filter
     assert os.environ['URLWATCH_JOB_NAME'] == 'should-not-be-overwritten'
+
+
+def test_html2text_does_not_modify_subfilter():
+    # The subfilter dict passed to Html2TextFilter should not be modified by
+    # the filter() method.
+    expected_subfilter = {'method': 're', 'extra_arg': 42}
+    subfilter = expected_subfilter.copy()
+    filtercls = FilterBase.__subclasses__.get('html2text')
+    filtercls(None, None).filter('unused', subfilter)
+    assert subfilter == expected_subfilter


### PR DESCRIPTION
Fixes #588

Deleting the 'method' key from a subfilter works when each job has its own subfilter dict. However, when the subfilter comes from job defaults, every job uses the same subfilter dict. Thus, the dict should not be modified so as to preserve it for use by other jobs.

This also adds a test for the specific behavior described in #588.  The test has been verified as failing prior to this change.  A more generic test that checks _no_ filters modify the subfilter dict would perhaps be better though not included in this PR.