### PR TITLE
Changes diff table colors and padding

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -168,14 +168,25 @@ class HtmlReporter(ReporterBase):
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <style type="text/css">
                 body { font-family: sans-serif; line-height: 1.5em; }
-                .diff_add { background-color: #e6ffec; display: inline-block;}
+                .diff_add { background-color: #e6ffec; display: inline-block; }
                 .diff_sub { background-color: #ffebe9; display: inline-block; }
                 .diff_chg { background-color: #f9e48b; display: inline-block; }
                 .unified_add { color: green; }
                 .unified_sub { color: red; }
                 .unified_nor { color: #333; }
+                td, th, colgroup { border: none; }
+                table, thead, tbody { border: 1px solid #9a9a9a; }
+                .diff_header { border-left: 1px solid #9a9a9a; }
+                td.diff_header { color: #6e7781; background-color: #f5f5f5; text-align: right; vertical-align: top; }
+                .diff_next { display: none; }
                 table { font-family: monospace; }
+                td, th { padding: 0 0.5em; }
                 h2 span.verb { color: #888; }
+                @media (prefers-color-scheme: dark ) {
+                    .diff_add { background-color: #1c4329; }
+                    .diff_sub { background-color: #542527; }
+                    .diff_chg { background-color: #907709; }
+                }
             </style>
         </head><body>
         """)

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -185,7 +185,7 @@ class HtmlReporter(ReporterBase):
                     body { background-color: #121212; color: #fff; }
                     a { color: #8ab5f8; }
                     a:visited { color: #c58af9; }
-                    td.diff_header, td.diff_next { background-color: #121212; }
+                    td.diff_header, td.diff_next { background-color: #1c1c1c; }
                     .diff_add { background-color: #1c4329; }
                     .diff_sub { background-color: #542527; }
                     .diff_chg { background-color: #907709; }

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -168,21 +168,24 @@ class HtmlReporter(ReporterBase):
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <style type="text/css">
                 body { font-family: sans-serif; line-height: 1.5em; }
-                .diff_add { background-color: #e6ffec; display: inline-block; }
-                .diff_sub { background-color: #ffebe9; display: inline-block; }
+                .diff_add { background-color: #abf2bc; display: inline-block; }
+                .diff_sub { background-color: #ffd7d5; display: inline-block; }
                 .diff_chg { background-color: #f9e48b; display: inline-block; }
                 .unified_add { color: green; }
                 .unified_sub { color: red; }
                 .unified_nor { color: #333; }
                 td, th, colgroup { border: none; }
                 table, thead, tbody { border: 1px solid #9a9a9a; }
-                .diff_header { border-left: 1px solid #9a9a9a; }
-                td.diff_header { color: #6e7781; background-color: #f5f5f5; text-align: right; vertical-align: top; }
-                .diff_next { display: none; }
+                .diff_next { border-left: 1px solid #9a9a9a; }
+                td.diff_header, td.diff_next { color: #6e7781; background-color: #f5f5f5; text-align: right; vertical-align: top; }
                 table { font-family: monospace; }
                 td, th { padding: 0 0.5em; }
                 h2 span.verb { color: #888; }
-                @media (prefers-color-scheme: dark ) {
+                @media (prefers-color-scheme: dark) {
+                    body { background-color: #121212; color: #fff; }
+                    a { color: #8ab5f8; }
+                    a:visited { color: #c58af9; }
+                    td.diff_header, td.diff_next { background-color: #121212; }
                     .diff_add { background-color: #1c4329; }
                     .diff_sub { background-color: #542527; }
                     .diff_chg { background-color: #907709; }

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -167,10 +167,10 @@ class HtmlReporter(ReporterBase):
             <meta http-equiv="content-type" content="text/html; charset=utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <style type="text/css">
-                body { font-family: sans-serif; }
-                .diff_add { color: green; background-color: lightgreen; }
-                .diff_sub { color: red; background-color: lightred; }
-                .diff_chg { color: orange; background-color: lightyellow; }
+                body { font-family: sans-serif; line-height: 1.5em; }
+                .diff_add { background-color: #e6ffec; display: inline-block;}
+                .diff_sub { background-color: #ffebe9; display: inline-block; }
+                .diff_chg { background-color: #f9e48b; display: inline-block; }
                 .unified_add { color: green; }
                 .unified_sub { color: red; }
                 .unified_nor { color: #333; }


### PR DESCRIPTION
This PR:
* Adjusts diff highlight colors used in the HTML table diff to match those used on github.com diff views.
* Includes support for dark mode by specifying alternate colors via the `prefers-color-scheme: dark` media query.
* Adds padding to the diff table for improved readability
* Selectively hides table borders for a cleaner view

The following screenshots were made on MacOS running Chrome.

### Before (light mode)
<img width="526" alt="Screen Shot 2022-11-30 at 2 01 41 PM" src="https://user-images.githubusercontent.com/4656936/204918605-cbb43785-331d-4b8b-ae85-645c5668e31f.png">

### After (light mode)
<img width="581" alt="Screen Shot 2022-11-30 at 2 01 48 PM" src="https://user-images.githubusercontent.com/4656936/204918626-e49223fd-9489-49f6-ba7c-531d1bbd16e1.png">

### Before (dark mode)
<img width="530" alt="Screen Shot 2022-11-30 at 2 02 32 PM" src="https://user-images.githubusercontent.com/4656936/204918613-2e83007b-8012-449a-8913-02dd2de6bfe9.png">

### After (dark mode)
<img width="572" alt="Screen Shot 2022-11-30 at 2 02 08 PM" src="https://user-images.githubusercontent.com/4656936/204918623-9f98bf77-a7a6-4ec5-b727-e59e31abce5e.png">


Fixes #729