### PR TITLE
shrink container image from 1g to 150m

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM python:3.10.0
+# https://hub.docker.com/_/python
+FROM python:3.11.0-alpine3.17
 
-RUN python3 -m pip install --no-cache-dir pyyaml minidb requests keyring appdirs lxml cssselect beautifulsoup4 jsbeautifier cssbeautifier aioxmpp
+# Optional python modules for additional functionality
+# https://urlwatch.readthedocs.io/en/latest/dependencies.html#optional-packages
+ENV OPT_PYPKGS="beautifulsoup4 jsbeautifier cssbeautifier aioxmpp"
+ENV HOME="/home/user"
 
-WORKDIR /opt/urlwatch
+RUN adduser -D user
+USER user
+WORKDIR $HOME
 
-COPY lib ./lib
-COPY share ./share
-COPY setup.py .
-COPY setup.cfg .
+COPY --chown=user . $HOME/urlwatch
 
-RUN python setup.py install
+RUN pip install \
+  --no-cache-dir \
+  ./urlwatch \
+  $OPT_PYPKGS \
+  && rm -rf urlwatch
 
-WORKDIR /root/.urlwatch
-
-ENTRYPOINT ["urlwatch"]
+ENV PATH="$HOME/.local/bin:$PATH"
+ENTRYPOINT ["/home/user/.local/bin/urlwatch"]


### PR DESCRIPTION
The original container build weighed in at 1.03g.  I switched it to the latest stable python 3.11.0 image based on Alpine Linux and this brings it down to 151m.  I tested with the latest stable with their Debian bullseye slim image and it comes to 228m.

I also converted the container to run as a user instead of root and use pip to install from local.

Let me know what you think.