### PR TITLE
Adds option to keep more than 1 historical snapshot when running with --gc-cache

### DIFF
--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -95,8 +95,8 @@ miscellaneous:
    --features
           list supported jobs/filters/reporters
 
-   --gc-cache
-          remove old cache entries
+   --gc-cache RETAIN_LIMIT
+          remove old cache entries, keeping the latest RETAIN_LIMIT (default: 1)
 
 
 Files

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -221,7 +221,7 @@ class UrlwatchCommand:
         if self.urlwatch_config.features:
             sys.exit(self.show_features())
         if self.urlwatch_config.gc_cache:
-            self.urlwatcher.cache_storage.gc([job.get_guid() for job in self.urlwatcher.jobs])
+            self.urlwatcher.cache_storage.gc([job.get_guid() for job in self.urlwatcher.jobs], self.urlwatch_config.gc_cache)
             sys.exit(0)
         if self.urlwatch_config.edit:
             sys.exit(self.urlwatcher.urls_storage.edit(self.urlwatch_config.urls_yaml_example))

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -220,7 +220,7 @@ class UrlwatchCommand:
     def handle_actions(self):
         if self.urlwatch_config.features:
             sys.exit(self.show_features())
-        if self.urlwatch_config.gc_cache:
+        if self.urlwatch_config.gc_cache is not None:
             self.urlwatcher.cache_storage.gc([job.get_guid() for job in self.urlwatcher.jobs], self.urlwatch_config.gc_cache)
             sys.exit(0)
         if self.urlwatch_config.edit:

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -108,7 +108,8 @@ class CommandConfig(BaseConfig):
         group.add_argument('--edit-hooks', action='store_true', help='edit hooks script')
         group = parser.add_argument_group('miscellaneous')
         group.add_argument('--features', action='store_true', help='list supported jobs/filters/reporters')
-        group.add_argument('--gc-cache', action='store_true', help='remove old cache entries')
+        group.add_argument('--gc-cache', metavar='RETAIN_LIMIT', type=int, help='remove old cache entries, keeping the latest RETAIN_LIMIT (default: 1)',
+                           nargs='?', const=1)
 
         args = parser.parse_args(cmdline_args)
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -587,7 +587,6 @@ class CacheMiniDBStorage(CacheStorage):
     def delete(self, guid):
         CacheEntry.delete_where(self.db, CacheEntry.c.guid == guid)
         self.db.commit()
-        pass
 
     def clean(self, guid, retain_limit=1):
         retain_limit = max(1, retain_limit)

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -468,6 +468,8 @@ class CacheStorage(BaseFileStorage, metaclass=ABCMeta):
             self.save(None, guid, data, timestamp, tries, etag)
 
     def gc(self, known_guids, retain_limit=1):
+        if retain_limit <= 0:
+            raise ValueError(f'Cache garbage collection must retain at least 1 historical snapshot per job (requested: {retain_limit})')
         for guid in set(self.get_guids()) - set(known_guids):
             print('Removing: {guid}'.format(guid=guid))
             self.delete(guid)


### PR DESCRIPTION
This is feature will be convenient for me, so I figured I'd make a PR in case you want to merge it in.  It generally adds flexibility to the db garbage collection while preserving existing behavior.

In summary:
* Pass an optional number after `--gc-cache` to retain that number of latest snapshots instead of always retaining only the most recent 1 snapshot.
* If no number is given, the program will default to keeping the latest 1 snapshot.  i.e. `--gc-cache` is equivalent to `--gc-cache 1`

I didn't see any existing tests for `storage.py` so I just did some tests on the command line.  I was not able to test with a redis db, but if required, I'm sure I could figure out how to get it set up. 

Here are the test results.

First, the jobs:
```
➜  urlwatch git:(feat/gc-limit) cat ~/urls.yaml                                                        
command: date
kind: shell
name: watchdog
---
command: date -R
kind: shell
name: watchdog2
```

The first job has some history whereas the second job is brand new:
```
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 1
==============================
2022-12-09 13:52
------------------------------
Fri Dec  9 13:52:24 PST 2022

============================== 

==============================
2022-12-09 13:53
------------------------------
Fri Dec  9 13:53:13 PST 2022

============================== 

==============================
2022-12-09 13:53
------------------------------
Fri Dec  9 13:53:15 PST 2022

============================== 

3 historic snapshot(s) available
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 2
0 historic snapshot(s) available
```

Running with `--gc-cache 2` retains the 2 most recent snapshots for job 1 and does nothing for job 2:
```
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --gc-cache 2    
Removed 1 old versions of e927d0677c77241b707442314346326278051dd6
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 1
==============================
2022-12-09 13:53
------------------------------
Fri Dec  9 13:53:13 PST 2022

============================== 

==============================
2022-12-09 13:53
------------------------------
Fri Dec  9 13:53:15 PST 2022

============================== 

2 historic snapshot(s) available
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 2
0 historic snapshot(s) available
```

Populate the snapshot history a bit for both jobs, resulting in 4 snapshots for job 1 and 2 snapshots for job 2...
```
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml                 
===========================================================================
01. CHANGED: watchdog
02. NEW: watchdog2
===========================================================================

➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml
===========================================================================
01. CHANGED: watchdog
02. CHANGED: watchdog2
===========================================================================

➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 1
==============================
2022-12-09 13:53
------------------------------
Fri Dec  9 13:53:13 PST 2022

============================== 

==============================
2022-12-09 13:53
------------------------------
Fri Dec  9 13:53:15 PST 2022

============================== 

==============================
2022-12-09 13:54
------------------------------
Fri Dec  9 13:54:28 PST 2022

============================== 

==============================
2022-12-09 13:54
------------------------------
Fri Dec  9 13:54:31 PST 2022

============================== 

4 historic snapshot(s) available
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 2
==============================
2022-12-09 13:54
------------------------------
Fri, 09 Dec 2022 13:54:28 -0800

============================== 

==============================
2022-12-09 13:54
------------------------------
Fri, 09 Dec 2022 13:54:31 -0800

============================== 

2 historic snapshot(s) available
```

... and run with no retain limit argument (i.e. `--gc-cache`), which preserves the old behavior of keeping the latest 1 snapshot:
```
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --gc-cache      
Removed 3 old versions of e927d0677c77241b707442314346326278051dd6
Removed 1 old versions of cdb05c1ba536b611913231a4561ab66b75774277
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 1
==============================
2022-12-09 13:54
------------------------------
Fri Dec  9 13:54:31 PST 2022

============================== 

1 historic snapshot(s) available
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --dump-history 2
==============================
2022-12-09 13:54
------------------------------
Fri, 09 Dec 2022 13:54:31 -0800

============================== 

1 historic snapshot(s) available
```

Invalid retain limit args are rejected:
```
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --gc-cache 0    
Traceback (most recent call last):
  File "./urlwatch", line 9, in <module>
    main()
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/cli.py", line 112, in main
    urlwatch_command.run()
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/command.py", line 431, in run
    self.handle_actions()
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/command.py", line 224, in handle_actions
    self.urlwatcher.cache_storage.gc([job.get_guid() for job in self.urlwatcher.jobs], self.urlwatch_config.gc_cache)
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/storage.py", line 472, in gc
    raise ValueError(f'Cache garbage collection must retain at least 1 historical snapshot per job (requested: {retain_limit})')
ValueError: Cache garbage collection must retain at least 1 historical snapshot per job (requested: 0)
➜  urlwatch git:(feat/gc-limit) ./urlwatch --urls ~/urls.yaml --config ~/urlwatch.yaml --gc-cache -2
Traceback (most recent call last):
  File "./urlwatch", line 9, in <module>
    main()
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/cli.py", line 112, in main
    urlwatch_command.run()
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/command.py", line 431, in run
    self.handle_actions()
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/command.py", line 224, in handle_actions
    self.urlwatcher.cache_storage.gc([job.get_guid() for job in self.urlwatcher.jobs], self.urlwatch_config.gc_cache)
  File "/Users/trevorshannon/projects/urlwatch/lib/urlwatch/storage.py", line 472, in gc
    raise ValueError(f'Cache garbage collection must retain at least 1 historical snapshot per job (requested: {retain_limit})')
ValueError: Cache garbage collection must retain at least 1 historical snapshot per job (requested: -2)
```