### PR TITLE
Remove outdated Python versions, add Python 3.11, fix CI builds

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --requirement requirements.txt
         python -m pip install pycodestyle==2.6.0 pytest
-        sudo apt install -y build-essential libpoppler-cpp-dev pkg-config python-dev tesseract-ocr
+        sudo apt install -y build-essential libpoppler-cpp-dev pkg-config python3-dev tesseract-ocr
         python -m pip install pdftotext docutils pygments pytesseract pillow jq
     - name: Test with pytest
       run: pytest -v

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - Docs: Re-group diff-related topics and improve wording (PR#712, by neutric)
 - Improved HTML e-mail diff style, including Dark Mode support (#730, by trevorshannon)
+- Require Python >= 3.7, as Python 3.6 was EOL'd on 2021-12-23
 
 ### Fixed
 

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -10,7 +10,7 @@ additional packages -- however, those are not needed to run urlwatch.
 Mandatory Packages
 ------------------
 
--  Python 3.6 or newer
+-  Python 3.7 or newer
 -  `PyYAML <http://pyyaml.org/>`__
 -  `minidb <https://thp.io/2010/minidb/>`__
 -  `requests <http://python-requests.org/>`__

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ with open(os.path.join('lib', 'urlwatch', '__init__.py')) as f:
 m = dict(re.findall("\n__([a-z]+)__ = '([^']+)'", main_py))
 docs = re.findall('"""(.*?)"""', main_py, re.DOTALL)
 
-if sys.version_info < (3, 6):
-    sys.exit('urlwatch requires Python 3.6 or newer')
+if sys.version_info < (3, 7):
+    sys.exit('urlwatch requires Python 3.7 or newer')
 
 m['name'] = 'urlwatch'
 m['author'], m['author_email'] = re.match(r'(.*) <(.*)>', m['author']).groups()


### PR DESCRIPTION
3.6 is EOL, 3.11 is new. And `python-dev` isn't a thing anymore in Debian.