### PR TITLE
Implements command to change a job location.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Document how to ignore whitespace changes (PR#707, by Paulo Magalhaes)
 - `shell` reporter: Call a script or program when chanegs are detected (fixes #650)
 - New `separate` configuration option for reporters to split reports into one-per-job (contributed by Ryne Everett)
+- `--change-location` option allowing job location to be changed without losing job history (#739, by trevorshannon)
 
 ### Changed
 

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -11,17 +11,6 @@ Quickly adding new URLs to the job list from the command line::
 
     urlwatch --add url=http://example.org,name=Example
 
-Updating a URL and keeping past history
----------------------------------------
-
-Job history is stored based on the value of the ``url`` parameter, so updating
-a job's URL in the configuration file ``urls.yaml`` will create a new job with 
-no history.  Retain history by using ``--change_location``::
-
-    urlwatch --change_location http://example.org#old http://example.org#new
-
-The command also works with Browser and Shell jobs, changing ``navigate`` and 
-``command`` respectively.
 
 Using word-based differences
 ----------------------------
@@ -381,6 +370,19 @@ the URLs, like this:
     url: http://example.com/#2
     filter:
       - grep: "Thing B"
+
+
+Updating a URL and keeping past history
+---------------------------------------
+
+Job history is stored based on the value of the ``url`` parameter, so updating
+a job's URL in the configuration file ``urls.yaml`` will create a new job with 
+no history.  Retain history by using ``--change-location``::
+
+    urlwatch --change-location http://example.org#old http://example.org#new
+
+The command also works with Browser and Shell jobs, changing ``navigate`` and 
+``command`` respectively.
 
 
 Running a subset of jobs

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -11,6 +11,17 @@ Quickly adding new URLs to the job list from the command line::
 
     urlwatch --add url=http://example.org,name=Example
 
+Updating a URL and keeping past history
+---------------------------------------
+
+Job history is stored based on the value of the ``url`` parameter, so updating
+a job's URL in the configuration file ``urls.yaml`` will create a new job with 
+no history.  Retain history by using ``--change_location``::
+
+    urlwatch --change_location http://example.org#old http://example.org#new
+
+The command also works with Browser and Shell jobs, changing ``navigate`` and 
+``command`` respectively.
 
 Using word-based differences
 ----------------------------

--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -72,6 +72,9 @@ job list management:
    --delete JOB
           delete job by location or index
 
+   --change_location JOB NEW_LOCATION
+          change the location of an existing job by location or index
+
    --test-filter JOB
           test filter output of job by location or index
 

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -216,8 +216,8 @@ class UrlwatchCommand:
             new_loc = self.urlwatch_config.change_location[1]
             # Ensure the user isn't overwriting an existing job with the change.
             if new_loc in (j.get_location() for j in self.urlwatcher.jobs):
-                print('The new location "%s" already exists for a job. Use that '
-                      'existing job or choose a different value.' % new_loc)
+                print(f'The new location "{new_loc}" already exists for a job. Use that '
+                      'existing job or choose a different value.')
                 save = False
             else:
                 job = self._find_job(self.urlwatch_config.change_location[0])
@@ -225,14 +225,14 @@ class UrlwatchCommand:
                     # Update the job's location (which will also update the
                     # guid) and move any history in the cache over to the job's
                     # updated guid.
-                    print('Moving location of %r to "%s"' % (job, new_loc))
+                    print(f'Moving location of {job!r} to "{new_loc}"')
                     old_guid = job.get_guid()
                     old_loc = job.get_location()
                     job.set_location(new_loc)
                     num_moved = self.urlwatcher.cache_storage.move(
                         old_guid, job.get_guid())
                     if num_moved:
-                        print('Moved %d snapshots of "%s" to "%s"' % (num_moved, old_loc, new_loc))
+                        print(f'Moved {num_moved} snapshots of "{old_loc}" to "{new_loc}"')
                 else:
                     print('Not found: %s' % self.urlwatch_config.change_location[0])
                     save = False

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -228,7 +228,7 @@ class UrlwatchCommand:
                     print(f'Moving location of {job!r} to "{new_loc}"')
                     old_guid = job.get_guid()
                     old_loc = job.get_location()
-                    job.set_location(new_loc)
+                    job.set_base_location(new_loc)
                     num_moved = self.urlwatcher.cache_storage.move(
                         old_guid, job.get_guid())
                     if num_moved:

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -216,8 +216,8 @@ class UrlwatchCommand:
             new_loc = self.urlwatch_config.change_location[1]
             # Ensure the user isn't overwriting an existing job with the change.
             if new_loc in (j.get_location() for j in self.urlwatcher.jobs):
-                print(f'The new location "{new_loc}" already exists for a job. Use that '
-                      'existing job or choose a different value.')
+                print(f'The new location "{new_loc}" already exists for a job. '
+                      'Delete the existing job or choose a different value.')
                 save = False
             else:
                 job = self._find_job(self.urlwatch_config.change_location[0])
@@ -234,7 +234,7 @@ class UrlwatchCommand:
                     if num_moved:
                         print(f'Moved {num_moved} snapshots of "{old_loc}" to "{new_loc}"')
                 else:
-                    print('Not found: %s' % self.urlwatch_config.change_location[0])
+                    print(f'Not found: {self.urlwatch_config.change_location[0]}')
                     save = False
 
         if save:

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -215,17 +215,17 @@ class UrlwatchCommand:
         if self.urlwatch_config.change_location is not None:
             new_loc = self.urlwatch_config.change_location[1]
             # Ensure the user isn't overwriting an existing job with the change.
-            if new_loc in [j.get_location() for j in self.urlwatcher.jobs]:
-                print('The new location "%s" already exists for a job. Use that'
-                      ' existing job or choose a different value.' % new_loc)
+            if new_loc in (j.get_location() for j in self.urlwatcher.jobs):
+                print('The new location "%s" already exists for a job. Use that '
+                      'existing job or choose a different value.' % new_loc)
                 save = False
             else:
                 job = self._find_job(self.urlwatch_config.change_location[0])
                 if job is not None:
-                    # Update the job's location (which will also update the 
-                    # guid) and move any history in the cache over to the job's 
+                    # Update the job's location (which will also update the
+                    # guid) and move any history in the cache over to the job's
                     # updated guid.
-                    print('Moving location of %s to "%s"' % (job, new_loc))
+                    print('Moving location of %r to "%s"' % (job, new_loc))
                     old_guid = job.get_guid()
                     old_loc = job.get_location()
                     job.set_location(new_loc)
@@ -234,7 +234,7 @@ class UrlwatchCommand:
                     if num_moved:
                         print('Moved %d snapshots of "%s" to "%s"' % (num_moved, old_loc, new_loc))
                 else:
-                    print('Not found: %r' % self.urlwatch_config.change_location[0])
+                    print('Not found: %s' % self.urlwatch_config.change_location[0])
                     save = False
 
         if save:
@@ -260,9 +260,9 @@ class UrlwatchCommand:
             sys.exit(self.dump_history(self.urlwatch_config.dump_history))
         if self.urlwatch_config.list:
             sys.exit(self.list_urls())
-        if (self.urlwatch_config.add is not None or 
-            self.urlwatch_config.delete is not None or 
-            self.urlwatch_config.change_location is not None):
+        if (self.urlwatch_config.add is not None
+                or self.urlwatch_config.delete is not None
+                or self.urlwatch_config.change_location is not None):
             sys.exit(self.modify_urls())
 
     def check_edit_config(self):

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -98,7 +98,7 @@ class CommandConfig(BaseConfig):
         group.add_argument('--list', action='store_true', help='list jobs')
         group.add_argument('--add', metavar='JOB', help='add job (key1=value1,key2=value2,...)')
         group.add_argument('--delete', metavar='JOB', help='delete job by location or index')
-        group.add_argument('--change_location', metavar=('JOB', 'NEW_LOCATION'), nargs=2, help='change the location of an existing job by location or index')
+        group.add_argument('--change-location', metavar=('JOB', 'NEW_LOCATION'), nargs=2, help='change the location of an existing job by location or index')
         group.add_argument('--test-filter', metavar='JOB', help='test filter output of job by location or index')
         group.add_argument('--test-diff-filter', metavar='JOB',
                            help='test diff filter output of job by location or index (needs at least 2 snapshots)')

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -98,6 +98,7 @@ class CommandConfig(BaseConfig):
         group.add_argument('--list', action='store_true', help='list jobs')
         group.add_argument('--add', metavar='JOB', help='add job (key1=value1,key2=value2,...)')
         group.add_argument('--delete', metavar='JOB', help='delete job by location or index')
+        group.add_argument('--change_location', metavar=('JOB', 'NEW_LOCATION'), nargs=2, help='change the location of an existing job by location or index')
         group.add_argument('--test-filter', metavar='JOB', help='test filter output of job by location or index')
         group.add_argument('--test-diff-filter', metavar='JOB',
                            help='test diff filter output of job by location or index (needs at least 2 snapshots)')

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -113,7 +113,7 @@ class JobBase(object, metaclass=TrackSubClasses):
     def get_location(self):
         raise NotImplementedError()
 
-    def set_location(self):
+    def set_base_location(self):
         raise NotImplementedError()
 
     def pretty_name(self):
@@ -215,11 +215,8 @@ class ShellJob(Job):
     def get_location(self):
         return self.user_visible_url or self.command
 
-    def set_location(self, location):
-        if self.user_visible_url:
-            self.user_visible_url = location
-        else:
-            self.command = location
+    def set_base_location(self, location):
+        self.command = location
 
     def retrieve(self, job_state):
         if not self.stderr or self.stderr == 'ignore':
@@ -268,11 +265,8 @@ class UrlJob(Job):
     def get_location(self):
         return self.user_visible_url or self.url
 
-    def set_location(self, location):
-        if self.user_visible_url:
-            self.user_visible_url = location
-        else:
-            self.url = location
+    def set_base_location(self, location):
+        self.url = location
 
     def retrieve(self, job_state):
         headers = {
@@ -417,11 +411,8 @@ class BrowserJob(Job):
     def get_location(self):
         return self.user_visible_url or self.navigate
 
-    def set_location(self, location):
-        if self.user_visible_url:
-            self.user_visible_url = location
-        else:
-            self.navigate = location
+    def set_base_location(self, location):
+        self.navigate = location
 
     def main_thread_enter(self):
         from .browser import BrowserContext

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -113,6 +113,9 @@ class JobBase(object, metaclass=TrackSubClasses):
     def get_location(self):
         raise NotImplementedError()
 
+    def set_location(self):
+        raise NotImplementedError()
+
     def pretty_name(self):
         raise NotImplementedError()
 
@@ -212,6 +215,12 @@ class ShellJob(Job):
     def get_location(self):
         return self.user_visible_url or self.command
 
+    def set_location(self, location):
+        if self.user_visible_url:
+            self.user_visible_url = location
+        else:
+            self.command = location
+
     def retrieve(self, job_state):
         if not self.stderr or self.stderr == 'ignore':
             # Report stderr output for non-zero exit code,
@@ -258,6 +267,12 @@ class UrlJob(Job):
 
     def get_location(self):
         return self.user_visible_url or self.url
+
+    def set_location(self, location):
+        if self.user_visible_url:
+            self.user_visible_url = location
+        else:
+            self.url = location
 
     def retrieve(self, job_state):
         headers = {
@@ -401,6 +416,12 @@ class BrowserJob(Job):
 
     def get_location(self):
         return self.user_visible_url or self.navigate
+
+    def set_location(self, location):
+        if self.user_visible_url:
+            self.user_visible_url = location
+        else:
+            self.navigate = location
 
     def main_thread_enter(self):
         from .browser import BrowserContext

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -535,6 +535,8 @@ class CacheDirStorage(CacheStorage):
         return 0
 
     def move(self, guid, new_guid):
+        if guid == new_guid:
+            return 0
         os.rename(self._get_filename(guid), self._get_filename(new_guid))
         return 1
 
@@ -619,13 +621,14 @@ class CacheMiniDBStorage(CacheStorage):
 
     def move(self, guid, new_guid):
         total_moved = 0
-        # Note if there are existing records with 'new_guid', they will
-        # not be overwritten and the job histories will be merged.
-        for entry in CacheEntry.load(self.db, CacheEntry.c.guid == guid):
-            entry.guid = new_guid
-            entry.save()
-            total_moved += 1
-        self.db.commit()
+        if guid != new_guid:
+            # Note if there are existing records with 'new_guid', they will
+            # not be overwritten and the job histories will be merged.
+            for entry in CacheEntry.load(self.db, CacheEntry.c.guid == guid):
+                entry.guid = new_guid
+                entry.save()
+                total_moved += 1
+            self.db.commit()
 
         return total_moved
 
@@ -700,6 +703,8 @@ class CacheRedisStorage(CacheStorage):
         return 0
 
     def move(self, guid, new_guid):
+        if guid == new_guid:
+            return 0
         key = self._make_key(guid)
         new_key = self._make_key(new_guid)
         # Note if a list with 'new_key' already exists, the data stored there

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -705,3 +705,4 @@ class CacheRedisStorage(CacheStorage):
         # Note if a list with 'new_key' already exists, the data stored there
         # will be overwritten.
         self.db.rename(key, new_key)
+        return self.db.llen(new_key)

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -702,6 +702,6 @@ class CacheRedisStorage(CacheStorage):
     def move(self, guid, new_guid):
         key = self._make_key(guid)
         new_key = self._make_key(new_guid)
-        # Note if a list with 'new_key' already exists, the data stored there 
+        # Note if a list with 'new_key' already exists, the data stored there
         # will be overwritten.
         self.db.rename(key, new_key)


### PR DESCRIPTION
This PR adds a new command line option `--change-location` to change the location (i.e. `url`, `command`, or `navigate`) of a job while preserving history for that job.  The tool ensures that the new location string is unique within the list of jobs prior to changing anything.

Note that in the (admittedly contrived) scenario of having abandoned entries in a redis db that use the user-provided new location (perhaps from old runs that were never garbage-collected) then those abandoned entries will be clobbered by the `--change-location` option.  I think that should be ok, but I'm sure I could find a way to preserve those entries if needed.

I did some manual testing to verify functionality.

Save the starting version of a simple urls YAML:
```
➜  urlwatch git:(feat/update-url)  cp ~/urls.yaml ~/urls_init.yaml
➜  urlwatch git:(feat/update-url) cat ~/urls_init.yaml 
command: date
kind: shell
---
kind: url
url: https://www.example.org
---
kind: url
url: https://www.wikipedia.org
user_visible_url: https://en.wikipedia.org
---
kind: browser
navigate: https://www.google.com
```

Change location of all 4 jobs:
```
➜  urlwatch git:(feat/update-url)  urlwatch --urls ~/urls.yaml --change-location 1 "date -v1m"                                
Moving location of <shell command='date'> to "date -v1m"
Saving updated list to '/Users/trevorshannon/urls.yaml'
➜  urlwatch git:(feat/update-url)  urlwatch --urls ~/urls.yaml --change-location https://www.example.org https://www.example.net
Moving location of <url url='https://www.example.org'> to "https://www.example.net"
Saving updated list to '/Users/trevorshannon/urls.yaml'
➜  urlwatch git:(feat/update-url)  urlwatch --urls ~/urls.yaml --change-location 3 https://es.wikipedia.org                     
Moving location of <url url='https://www.wikipedia.org' user_visible_url='https://en.wikipedia.org'> to "https://es.wikipedia.org"
Saving updated list to '/Users/trevorshannon/urls.yaml'
➜  urlwatch git:(feat/update-url)  urlwatch --urls ~/urls.yaml --change-location 4 https://www.google.co.uk
Moving location of <browser navigate='https://www.google.com'> to "https://www.google.co.uk"
Saving updated list to '/Users/trevorshannon/urls.yaml'
```

Compare the updated urls YAML to the initial reference version. Appropriate key values are updated according to job type:
```
➜  urlwatch git:(feat/update-url)  diff ~/urls_init.yaml ~/urls.yaml   
1c1
< command: date
---
> command: date -v1m
5c5
< url: https://www.example.org
---
> url: https://www.example.net
9c9
< user_visible_url: https://en.wikipedia.org
---
> user_visible_url: https://es.wikipedia.org
12c12
< navigate: https://www.google.com
---
> navigate: https://www.google.co.uk
```

Existing history is moved with --change-location:
```
➜  urlwatch git:(feat/update-url) urlwatch --urls ~/urls.yaml --dump-history 1
==============================
2022-12-20 13:08
------------------------------
Tue Dec 20 13:08:59 EST 2022

============================== 

==============================
2022-12-20 13:18
------------------------------
Tue Dec 20 13:18:54 EST 2022

============================== 

2 historic snapshot(s) available
➜  urlwatch git:(feat/update-url) urlwatch --urls ~/urls.yaml --change-location date "date -v1m"
Moving location of <shell command='date'> to "date -v1m"
Moved 2 snapshots of "date" to "date -v1m"
Saving updated list to '/Users/trevorshannon/urls.yaml'
➜  urlwatch git:(feat/update-url) urlwatch --urls ~/urls.yaml                                   
===========================================================================
01. CHANGED: date -v1m
===========================================================================

---------------------------------------------------------------------------
CHANGED: date -v1m
---------------------------------------------------------------------------
--- @	Tue, 20 Dec 2022 13:18:54 -0500
+++ @	Tue, 20 Dec 2022 13:20:33 -0500
@@ -1 +1 @@
-Tue Dec 20 13:18:54 EST 2022
+Thu Jan 20 13:20:33 EST 2022
---------------------------------------------------------------------------

➜  urlwatch git:(feat/update-url) urlwatch --urls ~/urls.yaml --dump-history 1                  
==============================
2022-12-20 13:08
------------------------------
Tue Dec 20 13:08:59 EST 2022

============================== 

==============================
2022-12-20 13:18
------------------------------
Tue Dec 20 13:18:54 EST 2022

============================== 

==============================
2022-12-20 13:20
------------------------------
Thu Jan 20 13:20:33 EST 2022

============================== 

3 historic snapshot(s) available
```

I confirmed the same behavior with `--cache redis://127.0.0.1:6379`

Fixes #300 