### PR TITLE
docs: Expand Configuration>Reporters section.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
@@ -31,6 +31,7 @@ release = '2.25'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'inheritance_ascii_tree',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -52,7 +53,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 master_doc = 'index'
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -67,14 +67,32 @@ current page contents.
 Reporters
 ---------
 
+"Reporters" are the modules that deliver notifications through their
+respective medium when they are enabled through the configuration file.
 
 .. only:: html or pdf
 
-    Configuration of reporters is described in :ref:`reporters`.
+    Reporter-specific options are described in :ref:`reporters`.
 
 .. only:: man
 
-    See :manpage:`urlwatch-reporters(5)` on the available reporters.
+    See :manpage:`urlwatch-reporters(5)` for reporter-specific options.
+
+In addition to the reporter-specific options, all reporters support these
+options:
+
+* ``enable``: *[bool]* Activate the reporter. **(required)**
+* ``separate``: *[bool]* Send a report for each job rather than a combined
+  report for all jobs. (default: False)
+
+Reporters are implemented in a hierarchy, such that these common configuration
+settings will apply to all descendent reporters:
+
+.. inheritance-ascii-tree:: urlwatch.reporters.ReporterBase
+
+.. note::
+   Setting the `email` reporter's `html` option to `true` will cause it to
+   inherit from the `html` configuration.
 
 Here is an example configuration that reports on standard
 output in color, as well as HTML e-mail using ``sendmail``:
@@ -104,14 +122,6 @@ output in color, as well as HTML e-mail using ``sendmail``:
 
 Any reporter-specific configuration must be below the ``report`` key
 in the configuration.
-
-Configuration settings like ``text``, ``html`` and ``markdown`` will
-apply to all reporters that derive from that reporter (for example,
-the ``stdout`` reporter uses ``text``, while the ``email`` reporter
-with ``html: true`` set uses ``html``).
-
-Setting ``separate: true`` will cause the reporter to send a report for
-each job rather than a combined report for all jobs.
 
 .. _job_defaults:
 

--- a/docs/source/inheritance_ascii_tree.py
+++ b/docs/source/inheritance_ascii_tree.py
@@ -1,0 +1,44 @@
+import importlib
+
+from docutils.nodes import literal_block
+from docutils.parsers.rst import Directive, directives
+
+
+def patch_subclasses(klass):
+    """ Recursively patch urlwatch classes to behave like standard python classes. """
+    klass.__subclasses__ = type.__subclasses__.__get__(klass)
+
+    for kls in klass.__subclasses__():
+        patch_subclasses(kls)
+
+
+def build_tree(klass, level):
+    """ Recurse into klass to build tree. """
+    for i, kls in enumerate(klass.__subclasses__()):
+        branch = '└───' if i + 1 == len(klass.__subclasses__()) else '├───'
+        indent = '│   ' * (level - 1)
+        yield ('' if level == 0 else indent + branch) + kls.__kind__
+
+        yield from build_tree(kls, level + 1)
+
+
+class InheritanceAsciiTree(Directive):
+    required_arguments = 1
+
+    def run(self):
+        rootparts = self.arguments.pop().split('.')
+        rootname = rootparts.pop()
+        rootmodulename = '.'.join(rootparts)
+
+        rootmodule = importlib.import_module(rootmodulename)
+        root = getattr(rootmodule, rootname)
+
+        patch_subclasses(root)
+
+        tree = (element for element in build_tree(root, 0))
+        treestring = '\n'.join(tree)
+        return [literal_block(treestring, treestring)]
+
+
+def setup(app):
+    app.add_directive('inheritance-ascii-tree', InheritanceAsciiTree)


### PR DESCRIPTION
- Diagram reporter hierarchy. This also serves to list the available reporters.
- More explicitly distinguish between common options and reporter-specific options.

I would note that I initially tried the `sphinx.ext.inheritance_diagram` directive but I found the resulting graphviz image buggy, hard to read, and also useless for the man page. So I implemented an extension myself and tried to mimick the unix `tree` command format, mostly due to lack of creativity.

```
   html
   text
   ├───stdout
   ├───email
   ├───ifttt
   ├───text
   │   ├───pushover
   │   └───pushbullet
   ├───mailgun
   ├───telegram
   ├───slack
   │   └───mattermost
   ├───discord
   ├───xmpp
   ├───prowl
   └───shell
   markdown
   └───matrix
```
