### PR TITLE
reporters: WebServiceReporter.__kind__

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -476,6 +476,8 @@ class IFTTTReport(TextReporter):
 class WebServiceReporter(TextReporter):
     MAX_LENGTH = 1024
 
+    __kind__ = 'webservice'
+
     def web_service_get(self):
         raise NotImplementedError
 


### PR DESCRIPTION
This is needed to properly outline the reporter hierarchy.