### PR TITLE
- Fix decoding of strings for Redis Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - html2text options were only applied to the first job when using `job_defaults`
   (PR#726, fixes #588, by trevorshannon)
 - Update Github tags watch filter documentation with new XPath (fixes #723, by Luis Aranguren)
+- Fix `--gc-cache` to clear unknown keys when using Redis storage (fixes #743, by scottmac) 
 
 ## [2.25] -- 2022-03-15
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -629,7 +629,7 @@ class CacheRedisStorage(CacheStorage):
     def get_guids(self):
         guids = []
         for guid in self.db.keys(b'guid:*'):
-            guids.append(str(guid[len('guid:'):]))
+            guids.append(guid[len('guid:'):].decode())
         return guids
 
     def load(self, job, guid):


### PR DESCRIPTION
Fixes #743, the strings weren't being decoded prior to adding them the list of known guids