### PR TITLE
Filters: Add 'sort' subfilter for xpath and css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 ## UNRELEASED
 
+### Added
+
+- `css` and `xpath` filters now accept a `sort` subfilter to sort matched elements lexicographically
+
 ### Fixed
 
 - Rework handling of running from a source checkout, fixes issues with example files

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -285,6 +285,30 @@ viewport size), you can use ``maxitems: 1`` to only return the first
 item.
 
 
+Fixing list reorderings with CSS Selector or XPath filters
+----------------------------------------------------------
+
+In some cases, the ordering of items on a webpage might change regularly
+without the actual content changing. By default, this would show up in
+the diff output as an element being removed from one part of the page and
+inserted in another part of the page.
+
+In cases where the order of items doesn't matter, it's possible to sort
+matched items lexicographically to avoid spurious reports when only the
+ordering of items changes on the page.
+
+The subfilter for ``css`` and ``xpath`` filters is ``sort``, and can be
+``true`` or ``false`` (the default):
+
+.. code:: yaml
+
+   url: https://example.org/items-random-order.html
+   filter:
+     - css:
+         selector: span.item
+         sort: true
+
+
 Filtering PDF documents
 -----------------------
 

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -674,6 +674,7 @@ class LxmlParser:
         self.namespaces = subfilter.get('namespaces')
         self.skip = int(subfilter.get('skip', 0))
         self.maxitems = int(subfilter.get('maxitems', 0))
+        self.sort_items = bool(subfilter.get('sort', False))
         if self.method not in ('html', 'xml'):
             raise ValueError('%s method must be "html" or "xml", got %r' % (filter_kind, self.method))
         if self.method == 'html' and self.namespaces is not None:
@@ -777,7 +778,8 @@ class LxmlParser:
             elements = elements[self.skip:]
         if self.maxitems:
             elements = elements[:self.maxitems]
-        return '\n'.join(self._to_string(element) for element in elements)
+        elements = (self._to_string(element) for element in elements)
+        return '\n'.join(sorted(elements) if self.sort_items else elements)
 
 
 LXML_PARSER_COMMON_SUBFILTERS = {
@@ -786,6 +788,7 @@ LXML_PARSER_COMMON_SUBFILTERS = {
     'namespaces': 'Mapping of XML namespaces for matching',
     'skip': 'Number of elements to skip from the beginning (default: 0)',
     'maxitems': 'Maximum number of items to return (default: all)',
+    'sort': 'Sort matched items after filtering (default: False)',
 }
 
 

--- a/lib/urlwatch/tests/data/filter_documentation_testdata.yaml
+++ b/lib/urlwatch/tests/data/filter_documentation_testdata.yaml
@@ -363,6 +363,22 @@ https://example.net/css-skip-maxitems.html:
     <div class="cpu">Pentium</div>
 
     <div class="cpu">Pentium MMX</div>
+https://example.org/items-random-order.html:
+  input: |
+    <body>
+      This is a test. <span class="item">B</span>
+      And some other content. <span class="item">D</span>
+      <span class="item">A</span> Sort it please.
+      Thank you. <span class="item">C</span>
+    </body>
+  output: |
+    <span class="item">A</span>
+
+    <span class="item">B</span>
+
+    <span class="item">C</span>
+
+    <span class="item">D</span>
 https://example.net/jobs.json:
   input: |
     [


### PR DESCRIPTION
Avoids spurious diffs on some pages that reorder items regularly.