### PR TITLE
Update asyncio coroutine syntax to Python 3.11+

### DIFF
--- a/lib/urlwatch/browser.py
+++ b/lib/urlwatch/browser.py
@@ -46,25 +46,23 @@ class BrowserLoop(object):
         self._loop_thread = threading.Thread(target=self._event_loop.run_forever)
         self._loop_thread.start()
 
-    @asyncio.coroutine
-    def _launch_browser(self):
-        browser = yield from pyppeteer.launch()
-        for p in (yield from browser.pages()):
-            yield from p.close()
+    async def _launch_browser(self):
+        browser = await pyppeteer.launch(headless=True, args=['--no-sandbox'])
+        for p in (await browser.pages()):
+            await p.close()
         return browser
 
-    @asyncio.coroutine
-    def _get_content(self, url, wait_until=None, useragent=None):
-        context = yield from self._browser.createIncognitoBrowserContext()
-        page = yield from context.newPage()
+    async def _get_content(self, url, wait_until=None, useragent=None):
+        context = await self._browser.createIncognitoBrowserContext()
+        page = await context.newPage()
         opts = {}
         if wait_until is not None:
             opts['waitUntil'] = wait_until
         if useragent is not None:
-            yield from page.setUserAgent(useragent)
-        yield from page.goto(url, opts)
-        content = yield from page.content()
-        yield from context.close()
+            await page.setUserAgent(useragent)
+        await page.goto(url, opts)
+        content = await page.content()
+        await context.close()
         return content
 
     def process(self, url, wait_until=None, useragent=None):


### PR DESCRIPTION
Cf. https://bugs.python.org/issue43216

Resolves the error when using the browser job type in Python 3.11.x:

Traceback (most recent call last):
  File "/[..]/lib/python3.11/site-packages/urlwatch/handler.py", line 68, in __enter__
    self.job.main_thread_enter()
  File "/[..]/lib/python3.11/site-packages/urlwatch/jobs.py", line 418, in main_thread_enter
    from .browser import BrowserContext
  File "/[..]/lib/python3.11/site-packages/urlwatch/browser.py", line 50
    browser = yield from pyppeteer.launch()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: 'yield from' inside async function

Also adds --no-sandbox as a default to the pyppeteer chromium invocation.

/DLange