### PR TITLE
reporters: test report jobs separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix documentation for watching Github tags and releases, again (#723)
+- Fix `--test-reporter` command-line option so `separate` configuration option is no longer ignored when sending test notifications (#772, by marunjar)
 
 ## [2.28] -- 2023-05-03
 

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -126,7 +126,12 @@ class ReporterBase(object, metaclass=TrackSubClasses):
         subclass = cls.__subclasses__[name]
         cfg = report.config['report'].get(name, {'enabled': False})
         if cfg['enabled']:
-            subclass(report, cfg, job_states, duration).submit()
+            base_config = subclass.get_base_config(report)
+            if base_config.get('separate', False):
+                for job_state in job_states:
+                    subclass(report, cfg, [job_state], duration).submit()
+            else:
+                subclass(report, cfg, job_states, duration).submit()
         else:
             raise ValueError('Reporter not enabled: {name}'.format(name=name))
 


### PR DESCRIPTION
This PR should make the `--test-reporter` option respect `separate` flag too.
It's just applying the changes already made with #721 from `submit_all` method to the `submit_one` method as well.

fixes #771

I hope this is ok so far, because my python is not the best :wink: