### PR TITLE
Applies larger line spacing only to diff tables.

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -185,7 +185,7 @@ class HtmlReporter(ReporterBase):
             <meta http-equiv="content-type" content="text/html; charset=utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <style type="text/css">
-                body { font-family: sans-serif; line-height: 1.5em; }
+                body { font-family: sans-serif; }
                 .diff_add { background-color: #abf2bc; display: inline-block; }
                 .diff_sub { background-color: #ffd7d5; display: inline-block; }
                 .diff_chg { background-color: #f9e48b; display: inline-block; }
@@ -196,7 +196,7 @@ class HtmlReporter(ReporterBase):
                 table, thead, tbody { border: 1px solid #9a9a9a; }
                 .diff_next { border-left: 1px solid #9a9a9a; }
                 td.diff_header, td.diff_next { color: #6e7781; background-color: #f5f5f5; text-align: right; vertical-align: top; }
-                table { font-family: monospace; }
+                table { font-family: monospace; line-height: 1.5em; }
                 td, th { padding: 0 0.5em; }
                 h2 span.verb { color: #888; }
                 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
This reverts the `<body>` line-height adjustment introduced in #730 and instead applies it to `<table>` elements so that the increased line-height only applies to HTML table diffs.  This higher line height was originally introduced to emulate the GitHub web diff rendering.

With this change, text-based diffs will go back to regular line heights.  See #774 

As a visual, here are the results of `diff: table` and `diff: unified` for the `html` reporter.  Note that these were rendered in Chrome as different email clients can render the HTML differently (e.g. web Gmail ignores the line-height anyway)

### Table (note 1.5 line height)
<img width="602" alt="Screenshot 2023-12-01 at 6 01 42 PM" src="https://github.com/thp/urlwatch/assets/4656936/20408bfe-f6d9-43bc-83da-29551787a6ae">

### Unified (note 1.0 line height)
<img width="414" alt="Screenshot 2023-12-01 at 6 02 55 PM" src="https://github.com/thp/urlwatch/assets/4656936/e65781c9-6d58-4c90-9d79-1391945b2a18">
