### PR TITLE
Fixes dark mode for HTML email reports on iOS Mail.

### DIFF
--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -184,7 +184,10 @@ class HtmlReporter(ReporterBase):
             <title>urlwatch</title>
             <meta http-equiv="content-type" content="text/html; charset=utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <meta name="color-scheme" content="light dark">
+            <meta name="supported-color-schemes" content="light dark only">
             <style type="text/css">
+                :root { color-scheme: light dark; supported-color-schemes: light dark; }
                 body { font-family: sans-serif; line-height: 1.5em; }
                 .diff_add { background-color: #abf2bc; display: inline-block; }
                 .diff_sub { background-color: #ffd7d5; display: inline-block; }
@@ -207,6 +210,7 @@ class HtmlReporter(ReporterBase):
                     .diff_add { background-color: #1c4329; }
                     .diff_sub { background-color: #542527; }
                     .diff_chg { background-color: #907709; }
+                    .unified_nor { color: #ddd; }
                 }
             </style>
         </head><body>


### PR DESCRIPTION
In particular, the unified diff view is now more readable (as raised by #774).

As I do not have an iOS device, I used litmus.com to verify this fix.

### At HEAD
<img width="283" alt="Screenshot 2023-12-01 at 8 48 22 PM" src="https://github.com/thp/urlwatch/assets/4656936/47b868d5-c2e7-42cd-b6a0-ce68c63e6fd4">


### With this PR
<img width="284" alt="Screenshot 2023-12-01 at 8 49 12 PM" src="https://github.com/thp/urlwatch/assets/4656936/1f4b5e46-1dbd-4ae9-8feb-a48e72a13592">
