### PR TITLE
SlackReporter with preformatted rich text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 ## UNRELEASED
 
+### Added
+
+- Slack Reporter: `rich_text` config option for preformatted rich text
+
 ### Changed
 
 - Remove EOL'd Python 3.7 (new minimum requirement is Python 3.8), add Python 3.12 testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 ### Added
 
-- Slack Reporter: `rich_text` config option for preformatted rich text
+- Slack Reporter: `rich_text` config option for preformatted rich text (#780, by vimagick)
 
 ### Changed
 

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -705,7 +705,7 @@ class SlackReporter(TextReporter):
 
     def submit_chunk(self, webhook_url, text):
         logger.debug("Sending {} request with text: {}".format(self.__kind__, text))
-        post_data = {"text": text}
+        post_data = self.prepare_post_data(text)
         result = requests.post(webhook_url, json=post_data)
         try:
             if result.status_code == requests.codes.ok:
@@ -719,11 +719,34 @@ class SlackReporter(TextReporter):
                                                                                         result.content))
         return result
 
+    def prepare_post_data(self, text):
+        if self.config.get('rich_text', False):
+            return {
+                "blocks": [
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_preformatted",
+                                "elements": [
+                                    {"type": "text", "text": text}
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        else:
+            return {"text": text}
+
 
 class MattermostReporter(SlackReporter):
     """Send a message to a Mattermost channel"""
 
     __kind__ = 'mattermost'
+
+    def prepare_post_data(self, text):
+        return {"text": text}
 
 
 class DiscordReporter(TextReporter):


### PR DESCRIPTION
Hi, I've updated my code ( #776 )

Three things:

- [x] Have you checked whether or not Mattermost supports Slack's rich text feature?

       Mattermost still use the original `{"text": text}`

- [x] How about users who want to opt out of this new behavior and have the old (non-rich-text) behavior? Should there be an option? What should be the default?

      Enabled only when `rich_text: true`

- [x] Please update CHANGELOG.md with information about this change

      Yes