### PR TITLE
Update CSS Selector to use new style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Fix documentation for watching Github tags and releases, again (#723)
 - Fix `--test-reporter` command-line option so `separate` configuration option is no longer ignored when sending test notifications (#772, by marunjar)
 - Fix line height and dark mode regression (#774 reported by kongomongo, PRs #777 and #778 by trevorshannon)
+- Fix compatibility with lxml >= 5 which caused the CSS Selector filter to fail (#783 reported by jamesquilty, PR #786 by jamstah)
 
 ## [2.28] -- 2023-05-03
 

--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -761,9 +761,9 @@ class LxmlParser:
         excluded_elems = None
         if self.filter_kind == 'css':
             selected_elems = CSSSelector(self.expression,
-                                         namespaces=self.namespaces).evaluate(root)
+                                         namespaces=self.namespaces)(root)
             excluded_elems = CSSSelector(self.exclude,
-                                         namespaces=self.namespaces).evaluate(root) if self.exclude else None
+                                         namespaces=self.namespaces)(root) if self.exclude else None
         elif self.filter_kind == 'xpath':
             selected_elems = root.xpath(self.expression, namespaces=self.namespaces)
             excluded_elems = root.xpath(self.exclude, namespaces=self.namespaces) if self.exclude else None


### PR DESCRIPTION
Fixes #783 

New style of calling the CSSSelector directly instead of using the evaluate function. This has been supported since lxml 1.1 [1] and the evaluate method has been deprecated since lxml 2.1 [2].

[1] https://github.com/lxml/lxml/blob/lxml-1.1/src/lxml/xpath.pxi#L66
[2] https://github.com/lxml/lxml/blob/lxml-2.1/src/lxml/xpath.pxi#L143