### PR TITLE
Skip site-packages dirs for pep8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Fix documentation for watching Github tags and releases, again (#723)
 - Fix `--test-reporter` command-line option so `separate` configuration option is no longer ignored when sending test notifications (#772, by marunjar)
 - Fix line height and dark mode regression (#774 reported by kongomongo, PRs #777 and #778 by trevorshannon)
+- Fix pep8 test to ignore files in the site-packages directory for cases where the venv is in the project directory (#788 by jamstah)
 
 ## [2.28] -- 2023-05-03
 

--- a/lib/urlwatch/tests/test_handler.py
+++ b/lib/urlwatch/tests/test_handler.py
@@ -82,8 +82,19 @@ def test_pep8_conformance():
     import pycodestyle
     style = pycodestyle.StyleGuide(ignore=['E501', 'E402', 'W503', 'E241'])
 
-    py_files = [y for x in os.walk(os.path.abspath('.')) for y in glob(os.path.join(x[0], '*.py'))]
-    result = style.check_files(py_files)
+    import site
+    site_packages = site.getsitepackages()
+
+    def py_files():
+        for dir, dirs, files in os.walk(os.path.abspath('.')):
+            if dir in site_packages:
+                dirs.clear()  # os.walk lets us modify the dirs list to prune the walk
+                files.clear()  # we also don't want to process files in the root of this excluded dir
+            for file in files:
+                if file.endswith('.py'):
+                    yield os.path.join(dir, file)
+
+    result = style.check_files(py_files())
     assert result.total_errors == 0, "Found #{0} code style errors".format(result.total_errors)
 
 


### PR DESCRIPTION
The venv doc says that a virtual environment is:
- Contained in a directory, conventionally either named venv or .venv in the project directory, or under a container directory for lots of virtual environments, such as ~/.virtualenvs.

This PR updates the pep8 test so that if the venv is in the project directory, the site-packages won't be tested.