### PR TITLE
Improves HTML diff table format for long line lengths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Fix documentation for watching Github tags and releases, again (#723)
 - Fix `--test-reporter` command-line option so `separate` configuration option is no longer ignored when sending test notifications (#772, by marunjar)
 - Fix line height and dark mode regression (#774 reported by kongomongo, PRs #777 and #778 by trevorshannon)
+- Fix HTML diff table rendering for long line lengths (#793 by trevorshannon)
 
 ## [2.28] -- 2023-05-03
 

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -201,6 +201,7 @@ class HtmlReporter(ReporterBase):
                 td.diff_header, td.diff_next { color: #6e7781; background-color: #f5f5f5; text-align: right; vertical-align: top; }
                 table { font-family: monospace; line-height: 1.5em; }
                 td, th { padding: 0 0.5em; }
+                td[nowrap] { white-space: normal; word-break: break-word; }
                 h2 span.verb { color: #888; }
                 @media (prefers-color-scheme: dark) {
                     body { background-color: #121212; color: #fff; }

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -201,7 +201,7 @@ class HtmlReporter(ReporterBase):
                 td.diff_header, td.diff_next { color: #6e7781; background-color: #f5f5f5; text-align: right; vertical-align: top; }
                 table { font-family: monospace; line-height: 1.5em; }
                 td, th { padding: 0 0.5em; }
-                td[nowrap] { width: 50%; white-space: normal; word-break: break-word; }
+                td[nowrap] { width: 50%; vertical-align: top; white-space: normal; word-break: break-word; }
                 h2 span.verb { color: #888; }
                 @media (prefers-color-scheme: dark) {
                     body { background-color: #121212; color: #fff; }

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -201,7 +201,7 @@ class HtmlReporter(ReporterBase):
                 td.diff_header, td.diff_next { color: #6e7781; background-color: #f5f5f5; text-align: right; vertical-align: top; }
                 table { font-family: monospace; line-height: 1.5em; }
                 td, th { padding: 0 0.5em; }
-                td[nowrap] { white-space: normal; word-break: break-word; }
+                td[nowrap] { width: 50%; white-space: normal; word-break: break-word; }
                 h2 span.verb { color: #888; }
                 @media (prefers-color-scheme: dark) {
                     body { background-color: #121212; color: #fff; }


### PR DESCRIPTION
If very long lines are present in an HTML diff report, the HTML table layout can become less than ideal.  One half of the diff can be very wide and the entire table can be wider than the screen.  

The built-in `difflib` output includes a `nowrap` HTML attribute on the table cells containing diff text lines.  However, wrapping diff lines is both useful and typical.  See the below GitHub diff screenshot for an example:

<img width="909" alt="Screenshot 2024-02-05 at 12 17 38 PM" src="https://github.com/thp/urlwatch/assets/4656936/95b78fcc-c68f-45e8-a320-fa1cde239cce">


This PR uses CSS to override that `nowrap` attribute and allow for sane line wrapping while also ensuring the left and right halves of the diff table are equal width.

### Current rendering:
Table is too wide for the viewport, left side is much narrower than the right.
<img width="1045" alt="Screenshot 2024-02-05 at 12 39 14 PM" src="https://github.com/thp/urlwatch/assets/4656936/90159f7a-ebc8-4c48-b6f8-916247d33f0c">

### Proposed rendering:
Table fits within the viewport, both sides are equal width, long diff lines are wrapped without adversely affecting line numbering.
<img width="1045" alt="Screenshot 2024-02-05 at 12 39 04 PM" src="https://github.com/thp/urlwatch/assets/4656936/8563c1f4-50c0-4608-818f-455f4551e5e6">
<img width="1045" alt="Screenshot 2024-02-05 at 12 39 37 PM" src="https://github.com/thp/urlwatch/assets/4656936/86f3e591-b2df-4db2-98f9-83fee914ff5b">



