### PR TITLE
Adds optional reply_to email reporter config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Remove EOL'd Python 3.7 (new minimum requirement is Python 3.8), add Python 3.12 testing
+- Adds optional reply_to option for email reporters (#794 by trevorshannon)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Remove EOL'd Python 3.7 (new minimum requirement is Python 3.8), add Python 3.12 testing
-- Adds optional reply_to option for email reporters (#794 by trevorshannon)
+- Adds optional `reply_to` option for email reporters (#794 by trevorshannon)
 
 ### Fixed
 

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -49,21 +49,23 @@ class Mailer(object):
     def send(self, msg):
         raise NotImplementedError
 
-    def msg_plain(self, from_email, to_email, subject, body):
+    def msg_plain(self, from_email, to_email, reply_to_email, subject, body):
         msg = email.mime.text.MIMEText(body, 'plain', 'utf-8')
         msg['Subject'] = subject
         msg['From'] = from_email
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
+        msg['Reply-To'] = reply_to_email
 
         return msg
 
-    def msg_html(self, from_email, to_email, subject, body_text, body_html):
+    def msg_html(self, from_email, to_email, reply_to_email, subject, body_text, body_html):
         msg = email.mime.multipart.MIMEMultipart('alternative')
         msg['Subject'] = subject
         msg['From'] = from_email
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
+        msg['Reply-To'] = reply_to_email
 
         msg.attach(email.mime.text.MIMEText(body_text, 'plain', 'utf-8'))
         msg.attach(email.mime.text.MIMEText(body_html, 'html', 'utf-8'))

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -56,7 +56,7 @@ class Mailer(object):
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
         if (reply_to_email):
-          msg['Reply-To'] = reply_to_email
+            msg['Reply-To'] = reply_to_email
 
         return msg
 
@@ -67,7 +67,7 @@ class Mailer(object):
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
         if (reply_to_email):
-          msg['Reply-To'] = reply_to_email
+            msg['Reply-To'] = reply_to_email
 
         msg.attach(email.mime.text.MIMEText(body_text, 'plain', 'utf-8'))
         msg.attach(email.mime.text.MIMEText(body_html, 'html', 'utf-8'))

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -55,7 +55,7 @@ class Mailer(object):
         msg['From'] = from_email
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
-        if (reply_to_email):
+        if reply_to_email:
             msg['Reply-To'] = reply_to_email
 
         return msg
@@ -66,7 +66,7 @@ class Mailer(object):
         msg['From'] = from_email
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
-        if (reply_to_email):
+        if reply_to_email:
             msg['Reply-To'] = reply_to_email
 
         msg.attach(email.mime.text.MIMEText(body_text, 'plain', 'utf-8'))

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -55,7 +55,8 @@ class Mailer(object):
         msg['From'] = from_email
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
-        msg['Reply-To'] = reply_to_email
+        if (reply_to_email):
+          msg['Reply-To'] = reply_to_email
 
         return msg
 
@@ -65,7 +66,8 @@ class Mailer(object):
         msg['From'] = from_email
         msg['To'] = to_email
         msg['Date'] = email.utils.formatdate()
-        msg['Reply-To'] = reply_to_email
+        if (reply_to_email):
+          msg['Reply-To'] = reply_to_email
 
         msg.attach(email.mime.text.MIMEText(body_text, 'plain', 'utf-8'))
         msg.attach(email.mime.text.MIMEText(body_html, 'html', 'utf-8'))

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -455,7 +455,7 @@ class EMailReporter(TextReporter):
         else:
             logger.error('Invalid entry for method {method}'.format(method=self.config['method']))
 
-        reply_to = self.config.get('reply_to', self.config['from'])
+        reply_to = self.config.get('reply_to', '')
         if self.config['html']:
             body_html = '\n'.join(self.convert(HtmlReporter).submit())
 

--- a/lib/urlwatch/reporters.py
+++ b/lib/urlwatch/reporters.py
@@ -455,12 +455,13 @@ class EMailReporter(TextReporter):
         else:
             logger.error('Invalid entry for method {method}'.format(method=self.config['method']))
 
+        reply_to = self.config.get('reply_to', self.config['from'])
         if self.config['html']:
             body_html = '\n'.join(self.convert(HtmlReporter).submit())
 
-            msg = mailer.msg_html(self.config['from'], self.config['to'], subject, body_text, body_html)
+            msg = mailer.msg_html(self.config['from'], self.config['to'], reply_to, subject, body_text, body_html)
         else:
-            msg = mailer.msg_plain(self.config['from'], self.config['to'], subject, body_text)
+            msg = mailer.msg_plain(self.config['from'], self.config['to'], reply_to, subject, body_text)
 
         mailer.send(msg)
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -101,6 +101,7 @@ DEFAULT_CONFIG = {
             'html': False,
             'to': '',
             'from': '',
+            'reply_to': '',
             'subject': '{count} changes: {jobs}',
             'method': 'smtp',
             'smtp': {


### PR DESCRIPTION
It can sometimes be useful to have a reply-to address different from the from address, especially when sending automated emails such as those generated by urlwatch.  If email reports are being sent to a distribution list, a reply-to address of that list makes more sense than the (likely unmonitored) bot address.

This PR adds the `reply_to` config option for the email reporter.  Note that the `Reply-To` header will now always be added to outgoing emails, but if the `reply_to` option is missing, that header will simply be populated with the same value as `From`