### PR TITLE
Move pep8 tests to own file

### DIFF
--- a/lib/urlwatch/tests/test_handler.py
+++ b/lib/urlwatch/tests/test_handler.py
@@ -77,27 +77,6 @@ def test_load_hooks_py():
         import_module_from_source('hooks', hooks_py)
 
 
-def test_pep8_conformance():
-    """Test that we conform to PEP-8."""
-    import pycodestyle
-    style = pycodestyle.StyleGuide(ignore=['E501', 'E402', 'W503', 'E241'])
-
-    import site
-    site_packages = site.getsitepackages()
-
-    def py_files():
-        for dir, dirs, files in os.walk(os.path.abspath('.')):
-            if dir in site_packages:
-                dirs.clear()  # os.walk lets us modify the dirs list to prune the walk
-                files.clear()  # we also don't want to process files in the root of this excluded dir
-            for file in files:
-                if file.endswith('.py'):
-                    yield os.path.join(dir, file)
-
-    result = style.check_files(py_files())
-    assert result.total_errors == 0, "Found #{0} code style errors".format(result.total_errors)
-
-
 class ConfigForTest(CommandConfig):
     def __init__(self, config, urls, cache, hooks, verbose):
         super().__init__([], 'urlwatch', os.path.dirname(__file__), root, config, urls, hooks, cache, verbose)

--- a/lib/urlwatch/tests/test_pep8.py
+++ b/lib/urlwatch/tests/test_pep8.py
@@ -1,0 +1,22 @@
+import pycodestyle
+import os
+import site
+
+
+def test_pep8_conformance():
+    """Test that we conform to PEP-8."""
+    style = pycodestyle.StyleGuide(ignore=['E501', 'E402', 'W503', 'E241'])
+
+    site_packages = site.getsitepackages()
+
+    def py_files():
+        for dir, dirs, files in os.walk(os.path.abspath('.')):
+            if dir in site_packages:
+                dirs.clear()  # os.walk lets us modify the dirs list to prune the walk
+                files.clear()  # we also don't want to process files in the root of this excluded dir
+            for file in files:
+                if file.endswith('.py'):
+                    yield os.path.join(dir, file)
+
+    result = style.check_files(py_files())
+    assert result.total_errors == 0, "Found #{0} code style errors".format(result.total_errors)


### PR DESCRIPTION
Its not really a handler test, so its cleaner to move it out.