### PR TITLE
add support for sending to multiple recipients via sendmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Fix multiple recipients for sendmail reporter (#797)
+- `email` reporter: Allow multiple recipients for `sendmail` method (#797, by monperrus)
 - Fix documentation for watching Github tags and releases, again (#723)
 - Fix `--test-reporter` command-line option so `separate` configuration option is no longer ignored when sending test notifications (#772, by marunjar)
 - Fix line height and dark mode regression (#774 reported by kongomongo, PRs #777 and #778 by trevorshannon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fix multiple recipients for sendmail reporter (#797)
 - Fix documentation for watching Github tags and releases, again (#723)
 - Fix `--test-reporter` command-line option so `separate` configuration option is no longer ignored when sending test notifications (#772, by marunjar)
 - Fix line height and dark mode regression (#774 reported by kongomongo, PRs #777 and #778 by trevorshannon)

--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -301,6 +301,7 @@ You can send email via the system's sendmail command provided by the MTA. You ne
       email:
         enabled: true
         from: 'postmaster@example.com'
+        to: 'recipient@bar.com'
         method: sendmail
 
 

--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -69,6 +69,7 @@ At the moment, the following reporters are built-in:
 - **prowl**: Send a detailed notification via prowlapp.com
 - **pushbullet**: Send summary via pushbullet.com
 - **pushover**: Send summary via pushover.net
+- **sendmail**: Pipe a message to the system sendmail command
 - **shell**: Pipe a message to a shell command
 - **slack**: Send a message to a Slack channel
 - **stdout**: Print summary on stdout (the console)

--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -61,7 +61,7 @@ The list of built-in reporters can be retrieved using::
 At the moment, the following reporters are built-in:
 
 - **discord**: Send a message to a Discord channel
-- **email**: Send summary via e-mail / SMTP
+- **email**: Send summary via e-mail / SMTP / sendmail
 - **ifttt**: Send summary via IFTTT
 - **mailgun**: Send e-mail via the Mailgun service
 - **matrix**: Send a message to a room using the Matrix protocol
@@ -69,7 +69,6 @@ At the moment, the following reporters are built-in:
 - **prowl**: Send a detailed notification via prowlapp.com
 - **pushbullet**: Send summary via pushbullet.com
 - **pushover**: Send summary via pushover.net
-- **sendmail**: Pipe a message to the system sendmail command
 - **shell**: Pipe a message to a shell command
 - **slack**: Send a message to a Slack channel
 - **stdout**: Print summary on stdout (the console)
@@ -290,6 +289,20 @@ public Matrix room, as the messages quickly become noisy:
      footer: false
      minimal: true
      enabled: true
+
+E-Mail via sendmail
+---------------------
+
+You can send email via the system's sendmail command provided by the MTA. You need to set "method: sendmail" in the config file.
+
+.. code:: yaml
+
+    report:
+      email:
+        enabled: true
+        from: 'postmaster@example.com'
+        method: sendmail
+
 
 E-Mail via GMail SMTP
 ---------------------

--- a/docs/source/reporters.rst
+++ b/docs/source/reporters.rst
@@ -293,7 +293,7 @@ public Matrix room, as the messages quickly become noisy:
 E-Mail via sendmail
 ---------------------
 
-You can send email via the system's sendmail command provided by the MTA. You need to set "method: sendmail" in the config file.
+You can send email via the system's ``sendmail`` command provided by the MTA. You need to set ``method: sendmail`` in the config file:
 
 .. code:: yaml
 

--- a/lib/urlwatch/mailer.py
+++ b/lib/urlwatch/mailer.py
@@ -112,7 +112,7 @@ class SendmailMailer(Mailer):
         self.sendmail_path = sendmail_path
 
     def send(self, msg):
-        p = subprocess.Popen([self.sendmail_path, '-oi', '-f', msg['From'], msg['To']],
+        p = subprocess.Popen([self.sendmail_path, '-oi', '-f', msg['From']] + msg['To'].split(','),
                              stdin=subprocess.PIPE,
                              stderr=subprocess.PIPE,
                              universal_newlines=True)


### PR DESCRIPTION
if the `to` config contains multiple emails such as `x@foo.com,y@bar.com`