### PR TITLE
Fix IndexError after failed edit

### DIFF
--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -278,7 +278,7 @@ class BaseTextualFileStorage(BaseFileStorage, metaclass=ABCMeta):
                 print('')
                 print('The file', file_edit, 'was NOT updated.')
                 user_input = input("Do you want to retry the same edit? (y/n)")
-                if user_input.lower()[0] == 'y':
+                if user_input.lower()[:1] == 'y':
                     continue
                 print('Your changes have been saved in', file_edit)
                 return 1


### PR DESCRIPTION
Fixes:

    IndexError: string index out of range

if the user just pressed enter after the "Do you want to retry the same edit?" question.