### PR TITLE
Replace the dead appdirs dependency by platformdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - Remove EOL'd Python 3.7 (new minimum requirement is Python 3.8), add Python 3.12 testing
 - Adds optional `reply_to` option for email reporters (#794 by trevorshannon)
-- Replace the dead depency `appdirs` by `platformdirs` (by Maxime Werlen)
+- Replace the dead dependency `appdirs` with `platformdirs` (#811 by Maxime Werlen)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - Remove EOL'd Python 3.7 (new minimum requirement is Python 3.8), add Python 3.12 testing
 - Adds optional `reply_to` option for email reporters (#794 by trevorshannon)
+- Replace the dead depency `appdirs` by `platformdirs` (by Maxime Werlen)
 
 ### Fixed
 

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -15,7 +15,7 @@ Mandatory Packages
 -  `minidb <https://thp.io/2010/minidb/>`__
 -  `requests <http://python-requests.org/>`__
 -  `keyring <https://github.com/jaraco/keyring/>`__
--  `appdirs <https://github.com/ActiveState/appdirs>`__
+-  `platformdirs <https://github.com/platformdirs/platformdirs>`__
 -  `lxml <https://lxml.de>`__
 -  `cssselect <https://cssselect.readthedocs.io>`__
 

--- a/lib/urlwatch/cli.py
+++ b/lib/urlwatch/cli.py
@@ -35,14 +35,14 @@ import os.path
 import signal
 import sys
 
-from appdirs import AppDirs
+from platformdirs import PlatformDirs
 
 pkgname = 'urlwatch'
 urlwatch_dir = os.path.expanduser(os.path.join('~', '.' + pkgname))
-urlwatch_cache_dir = AppDirs(pkgname).user_cache_dir
+urlwatch_cache_dir = PlatformDirs(pkgname).user_cache_dir
 
 if not os.path.exists(urlwatch_dir):
-    urlwatch_dir = AppDirs(pkgname).user_config_dir
+    urlwatch_dir = PlatformDirs(pkgname).user_config_dir
 
 # Check if we are installed in the system already
 (prefix, bindir) = os.path.split(os.path.dirname(os.path.abspath(sys.argv[0])))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pyyaml
 minidb >= 2.0.6
 requests
 keyring
-appdirs
+platformdirs
 lxml
 cssselect

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if sys.version_info < (3, 8):
 m['name'] = 'urlwatch'
 m['author'], m['author_email'] = re.match(r'(.*) <(.*)>', m['author']).groups()
 m['description'], m['long_description'] = docs[0].strip().split('\n\n', 1)
-m['install_requires'] = ['minidb>=2.0.6', 'PyYAML', 'requests', 'keyring', 'appdirs', 'lxml', 'cssselect']
+m['install_requires'] = ['minidb>=2.0.6', 'PyYAML', 'requests', 'keyring', 'platformdirs', 'lxml', 'cssselect']
 if sys.platform == 'win32':
     m['install_requires'].extend(['colorama'])
 m['entry_points'] = {"console_scripts": ["urlwatch=urlwatch.cli:main"]}


### PR DESCRIPTION
Hello,

python3-appdirs has been announced as [dead upstream](https://github.com/ActiveState/appdirs/commit/8734277956c1df3b85385e6b308e954910533884) and its Debian maintainer has indicated that it should not be included in trixie (the next stable release). A recommended replacement is [python3-platformdirs](https://pypi.org/project/platformdirs/), which is a fork of appdirs with a very similar API.

I've prepared this MR to apply the recommanded easy replacement.
This change conserve the path of the cache and config dirs.

Maxime