### PR TITLE
Upgrade minidb to 2.0.8 (fixes #779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Fix pep8 test to ignore files in the site-packages directory for cases where the venv is in the project directory (#788 by jamstah)
 - Fix HTML diff table rendering for long line lengths (#793 by trevorshannon)
 - Fix IndexError after failed edit (#801 by jwilk)
+- Fix concurrency issue in Python 3.12 by upgrading to minidb 2.0.8 (fixes #779)
 
 ## [2.28] -- 2023-05-03
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml
-minidb >= 2.0.6
+minidb >= 2.0.8
 requests
 keyring
 platformdirs


### PR DESCRIPTION
#806 might still be nice to get merged (cc @Jamstah), though. But this imports the fixed minidb release.