### PR TITLE
If tags is a string, use it as a single tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - New `enabled` option for all jobs. Set to false to disable a job without needing to remove it or comment it out (Requested in #625 by snowman, contributed in #785 by jamstah)
 - New option `ignore_incomplete_reads` (Requested in #725 by wschoot, contributed in #787 by wfrisch)
 - New option `wait_for` in browser jobs (Requested in #763 by yuis-ice, contributed in #810 by jamstah)
-- Added tags to jobs and the ability to select them at the command line (#789 by jamstah)
+- Added tags to jobs and the ability to select them at the command line (#789, #824 by jamstah)
 
 ### Changed
 

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -172,7 +172,7 @@ Optional keys for all job types
 -------------------------------
 
 - ``name``: Human-readable name/label of the job
-- ``tags``: Array of tags
+- ``tags``: Array of tags, or a single tag as a string
 - ``filter``: :doc:`filters` (if any) to apply to the output (can be tested with ``--test-filter``)
 - ``max_tries``: After this many sequential failed runs, the error will be reported rather than ignored
 - ``diff_tool``: Command to a custom tool for generating diff text

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -35,7 +35,7 @@ import os
 import re
 import subprocess
 import textwrap
-from typing import Iterable, Optional, Set, FrozenSet
+from typing import Iterable, Optional, Set, FrozenSet, Sequence
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -220,6 +220,8 @@ class Job(JobBase):
     def tags(self, value: Optional[Iterable[str]]):
         if value is None:
             self._tags = None
+        elif isinstance(value, str):
+            self._tags = frozenset([str])
         else:
             self._tags = frozenset(value)
 


### PR DESCRIPTION
I accidentally forgot to make it an array in my yaml and nothing complained, but it wasn't working.