### PR TITLE
CI maintenance (update actions, add Python 3.13)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,10 +21,11 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13.0-rc.2'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
The title says it all. 3.13 will be released soon, so adding it to CI now makes sense, even though we have to use the release candidate with actions/setup-python.