### PR TITLE
Bump minimum Python version to 3.9

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,12 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
-          - '3.13.0-rc.2'
+          - '3.13'
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## UNRELEASED
+
+### Changed
+
+- Remove EOL'd Python 3.8 (new minimum requirement is Python 3.9), add Python 3.13 testing
+
 ## [2.29] -- 2024-10-28
 
 ### Added

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -10,7 +10,7 @@ additional packages -- however, those are not needed to run urlwatch.
 Mandatory Packages
 ------------------
 
--  Python 3.8 or newer
+-  Python 3.9 or newer
 -  `PyYAML <http://pyyaml.org/>`__
 -  `minidb <https://thp.io/2010/minidb/>`__
 -  `requests <http://python-requests.org/>`__

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ with open(os.path.join('lib', 'urlwatch', '__init__.py')) as f:
 m = dict(re.findall("\n__([a-z]+)__ = '([^']+)'", main_py))
 docs = re.findall('"""(.*?)"""', main_py, re.DOTALL)
 
-if sys.version_info < (3, 8):
-    sys.exit('urlwatch requires Python 3.8 or newer')
+if sys.version_info < (3, 9):
+    sys.exit('urlwatch requires Python 3.9 or newer')
 
 m['name'] = 'urlwatch'
 m['author'], m['author_email'] = re.match(r'(.*) <(.*)>', m['author']).groups()


### PR DESCRIPTION
Python 3.8 became EOL'd on 2024-10-07, see: https://devguide.python.org/versions/