### PR TITLE
Add option to preserve ids that are provided as arguments with --prepare-jobs

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -143,15 +143,15 @@ class UrlwatchCommand:
         return 0
 
     def prepare_jobs(self):
-        new_jobs = []
+        new_jobs = {*()}
         for idx, job in enumerate(self.urlwatcher.jobs):
             has_history = self.urlwatcher.cache_storage.has_history_data(job.get_guid())
             if not has_history:
                 logger.info('Add Job: %s', job.pretty_name())
-                new_jobs.append(idx + 1)
-        if not new_jobs:
+                new_jobs.add(idx + 1)
+        if not new_jobs and not self.urlwatch_config.idx_set:
             return 0
-        self.urlwatch_config.idx_set = frozenset(new_jobs)
+        self.urlwatch_config.idx_set = self.urlwatch_config.idx_set.union(new_jobs)
         self.urlwatcher.run_jobs()
         self.urlwatcher.close()
 


### PR DESCRIPTION
If you try to combine `--prepare-jobs` and running Job IDs in one command the ids got ignore since prepare_jobs overrides the set.

With this small change we use a set instead of a list we use a set and merge them later together to preserve other scheduled jobs.

With this we can use for example `urlwatch 1 2 3 4 --prepare-jobs`