### PR TITLE
Update filter for gitlab.com tags.

### DIFF
--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -475,7 +475,7 @@ and for Gitlab tags:
 
    url: https://gitlab.com/chinstrap/gammastep/-/tags
    filter:
-     - xpath: (//a[contains(@class,"item-title ref-name")])[1]
+     - xpath: (//*[@class="gl-font-bold"])[1]
      - html2text
 
 Alternatively, ``jq`` can be used for filtering:

--- a/lib/urlwatch/tests/data/filter_documentation_testdata.yaml
+++ b/lib/urlwatch/tests/data/filter_documentation_testdata.yaml
@@ -271,9 +271,9 @@ https://github.com/thp/urlwatch/tags:
     2.28
 https://gitlab.com/chinstrap/gammastep/-/tags:
   input: |-
-    <a class="item-title ref-name" href="/chinstrap/gammastep/-/tags/v2.0.7">v2.0.7</a>
+    <a class="gl-font-bold" href="/chinstrap/gammastep/-/tags/v2.0.9">v2.0.9</a>
   output: |-
-    v2.0.7
+    v2.0.9
 https://example.com/regex-substitute.html:
   input: |-
     <div>


### PR DESCRIPTION
The previous one stopped working.