### PR TITLE
Fix minor bugs on tags filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - Fix shell reporter running even when diff is empty (#837, by MarcPer)
 - Filter for gitlab.com tags fixed (#839, by julianuu)
+- Fix `TypeError` when jobs don't have tags (#843 by Maxime Werlen)
 
 ## [2.29] -- 2024-10-28
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -200,6 +200,8 @@ class Job(JobBase):
     __optional__ = ('name', 'filter', 'max_tries', 'diff_tool', 'compared_versions', 'diff_filter', 'enabled', 'treat_new_as_changed', 'user_visible_url', 'tags')
 
     def matching_tags(self, tags: Set[str]) -> Set[str]:
+        if self.tags is None:
+            return False
         return self.tags & tags
 
     # determine if hyperlink "a" tag is used in HtmlReporter
@@ -221,7 +223,7 @@ class Job(JobBase):
         if value is None:
             self._tags = None
         elif isinstance(value, str):
-            self._tags = frozenset([str])
+            self._tags = frozenset([value])
         else:
             self._tags = frozenset(value)
 


### PR DESCRIPTION
Hi,

A debian user opened [a bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1104785) concerning the tags filter.
It seems there is no protection when some jobs don't have tags, `self.tags` is then `None` and it throws a `TypeError`.

This PR is a fix for this specific case.
I also fixed a small error when a tag was set as a string instead of an array.

Regards

Maxime