### PR TITLE
Upgrade pycodestyle test dependency

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --requirement requirements.txt
-        python -m pip install pycodestyle==2.6.0 pytest
+        python -m pip install pycodestyle==2.14.0 pytest
         sudo apt-get update
         sudo apt-get install -y build-essential libpoppler-cpp-dev pkg-config python3-dev tesseract-ocr
         python -m pip install pdftotext docutils pygments pytesseract pillow jq


### PR DESCRIPTION
Older pycodestyle versions have issues with newer Python versions; see

https://pycodestyle.pycqa.org/en/latest/developer.html#changes