### PR TITLE
Update Dockerfile base image to Python 3.12.12 and Alpine 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/python
-FROM python:3.12.0-alpine3.18
+FROM python:3.12.12-alpine3.23
 
 # Optional python modules for additional functionality
 # https://urlwatch.readthedocs.io/en/latest/dependencies.html#optional-packages


### PR DESCRIPTION
Alpine releases are supported for 2 years. Alpine 3.18.0 was released on 2023-05-09, so support for 3.18 ended on 2025-05-09.

Python 3.12.12 was released on 2025-10-09 and is a security release for the 3.12 series.

Sources
- https://alpinelinux.org/releases/
- https://alpinelinux.org/posts/Alpine-3.18.0-released.html
- https://www.python.org/downloads/latest/python3.12/