### PR TITLE
Close database for non-reporting commands (Fixes #860)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 - Fix shell reporter running even when diff is empty (#837, by MarcPer)
 - Filter for gitlab.com tags fixed (#839, by julianuu)
 - Fix `TypeError` when jobs don't have tags (#843 by Maxime Werlen)
+- Fix `ResourceWarning` when running non-reporting commands (#865, reported by Hanno Böck)
 
 ## [2.29] -- 2024-10-28
 

--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -485,11 +485,13 @@ class UrlwatchCommand:
             sys.exit(0)
 
     def run(self):
-        self.check_edit_config()
-        self.check_smtp_login()
-        self.check_telegram_chats()
-        self.check_xmpp_login()
-        self.check_test_reporter()
-        self.handle_actions()
-        self.urlwatcher.run_jobs()
-        self.urlwatcher.close()
+        try:
+            self.check_edit_config()
+            self.check_smtp_login()
+            self.check_telegram_chats()
+            self.check_xmpp_login()
+            self.check_test_reporter()
+            self.handle_actions()
+            self.urlwatcher.run_jobs()
+        finally:
+            self.urlwatcher.close()

--- a/lib/urlwatch/main.py
+++ b/lib/urlwatch/main.py
@@ -107,7 +107,7 @@ class Urlwatch(object):
 
     def run_jobs(self):
         run_jobs(self)
+        self.report.finish()
 
     def close(self):
-        self.report.finish()
         self.cache_storage.close()


### PR DESCRIPTION
This avoids warnings like this one:

```
<sys>:0: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x...>
````

Thanks to @hannob for reporting.