### PR TITLE
Add json option for url jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - New command-line option `--prepare-jobs` to initialize new jobs or jobs without history (#831 by nille02)
 - New reporter: `ntfy` (#854 by fyrk)
+- New `json` option for `url` jobs: when set to `true`, serializes `data` as JSON and sets `Content-type: application/json`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format mostly follows [Keep a Changelog](http://keepachangelog.com/en/1.0.0/
 
 - New command-line option `--prepare-jobs` to initialize new jobs or jobs without history (#831 by nille02)
 - New reporter: `ntfy` (#854 by fyrk)
-- New `json` option for `url` jobs: when set to `true`, serializes `data` as JSON and sets `Content-type: application/json`
+- New boolean `json` option for `url` jobs: serializes `data` as JSON and sets `Content-type: application/json` (contributed in #866 by Louis Sautier)
 
 ### Changed
 

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -445,6 +445,25 @@ allowing you to send arbitrary requests to the server:
       Content-type: application/json
     data: '{"foo": true}'
 
+
+Sending JSON data using POST
+----------------------------
+
+For JSON API endpoints, set ``json: true`` alongside ``data`` (as a native
+YAML mapping). urlwatch will serialize ``data`` to JSON and set
+``Content-type`` to ``application/json`` automatically. As with plain
+``data``, the HTTP method defaults to ``POST``:
+
+.. code-block:: yaml
+
+    name: "My JSON API Job"
+    url: http://example.com/api/query
+    json: true
+    data:
+      query: "status"
+      limit: 10
+      tags: ["foo", "bar"]
+
 .. only:: man
 
     See also

--- a/docs/source/jobs.rst
+++ b/docs/source/jobs.rst
@@ -49,6 +49,7 @@ Job-specific optional keys:
 - ``cookies``: Cookies to send with the request (see :ref:`advanced_topics`)
 - ``method``: HTTP method to use (default: ``GET``)
 - ``data``: HTTP POST/PUT data
+- ``json``: If ``true``, serialize ``data`` as JSON and set ``Content-type`` to ``application/json`` (default: ``false``)
 - ``ssl_no_verify``: Do not verify SSL certificates (true/false)
 - ``ignore_cached``: Do not use cache control (ETag/Last-Modified) values (true/false)
 - ``http_proxy``: Proxy server to use for HTTP requests (might be http:// or socks5://)

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -280,9 +280,9 @@ class UrlJob(Job):
     __kind__ = 'url'
 
     __required__ = ('url',)
-    __optional__ = ('cookies', 'data', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy', 'https_proxy',
-                    'headers', 'ignore_connection_errors', 'ignore_http_error_codes', 'encoding', 'timeout',
-                    'ignore_timeout_errors', 'ignore_too_many_redirects', 'ignore_incomplete_reads')
+    __optional__ = ('cookies', 'data', 'json', 'method', 'ssl_no_verify', 'ignore_cached', 'http_proxy',
+                    'https_proxy', 'headers', 'ignore_connection_errors', 'ignore_http_error_codes', 'encoding',
+                    'timeout', 'ignore_timeout_errors', 'ignore_too_many_redirects', 'ignore_incomplete_reads')
 
     CHARSET_RE = re.compile('text/(html|plain); charset=([^;]*)')
 
@@ -317,7 +317,10 @@ class UrlJob(Job):
         if self.data is not None:
             if self.method is None:
                 self.method = "POST"
-            headers['Content-type'] = 'application/x-www-form-urlencoded'
+            if self.json:
+                headers['Content-type'] = 'application/json'
+            else:
+                headers['Content-type'] = 'application/x-www-form-urlencoded'
             logger.info('Sending %s request to %s', self.method, self.url)
 
         if self.method is None:
@@ -347,7 +350,8 @@ class UrlJob(Job):
             timeout = self.timeout
 
         response = requests.request(url=self.url,
-                                    data=self.data,
+                                    data=None if self.json else self.data,
+                                    json=self.data if self.json else None,
                                     headers=headers,
                                     method=self.method,
                                     verify=(not self.ssl_no_verify),

--- a/share/man/man5/urlwatch-jobs.5
+++ b/share/man/man5/urlwatch-jobs.5
@@ -86,6 +86,8 @@ Job\-specific optional keys:
 .IP \(bu 2
 \fBdata\fP: HTTP POST/PUT data
 .IP \(bu 2
+\fBjson\fP: If \fBtrue\fP, serialize \fBdata\fP as JSON and set \fBContent\-type\fP to \fBapplication/json\fP (default: \fBfalse\fP)
+.IP \(bu 2
 \fBssl_no_verify\fP: Do not verify SSL certificates (true/false)
 .IP \(bu 2
 \fBignore_cached\fP: Do not use cache control (ETag/Last\-Modified) values (true/false)


### PR DESCRIPTION
Hi,

When set alongside data, serializes the payload as JSON and sets
Content-type: application/json. This lets users specify JSON request
bodies as native YAML mappings instead of embedding escaped JSON
strings in data.
