### PR TITLE
Don't check reporters are enabled if they aren't run

### DIFF
--- a/lib/urlwatch/main.py
+++ b/lib/urlwatch/main.py
@@ -109,10 +109,10 @@ class Urlwatch(object):
         run_jobs(self)
         self.report.finish()
 
-    def close(self):
         if not self.report.reporters_enabled:
             logger.warning('No reporters enabled.')
 
+    def close(self):
         for job_state in self.report.job_states:
             if not job_state.reported_count:
                 logger.warning(f'Job {job_state.job.pretty_name()} was not reported on')


### PR DESCRIPTION
https://github.com/thp/urlwatch/pull/822 introduced a bug - running a command that doesn't run reporters (like `--list`) now fails because it tries to check if the reporters were run can't because the dynamic attribute is only set during the reporter runs.

This PR moves the check to behind where the reporters are called. Interestingly, when one reporter is selected that was already the behaviour.

```
(venv) jammy@mac007470 urlwatch % ./urlwatch --config lib/urlwatch/tests/data/urlwatch.yaml --urls lib/urlwatch/tests/data/jobs-with-tags.yaml --list
1: UTC ( date -u )
2: RFC ( date -R )
3: Local ( date )
4: Static ( echo hi )
Traceback (most recent call last):
  File "/Users/jammy/workspaces/urlwatch/lib/urlwatch/command.py", line 497, in run
    self.handle_actions()
  File "/Users/jammy/workspaces/urlwatch/lib/urlwatch/command.py", line 295, in handle_actions
    sys.exit(self.list_urls())
SystemExit: 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jammy/workspaces/urlwatch/./urlwatch", line 17, in <module>
    cli.main()
  File "/Users/jammy/workspaces/urlwatch/lib/urlwatch/cli.py", line 109, in main
    urlwatch_command.run()
  File "/Users/jammy/workspaces/urlwatch/lib/urlwatch/command.py", line 500, in run
    self.urlwatcher.close()
  File "/Users/jammy/workspaces/urlwatch/lib/urlwatch/main.py", line 113, in close
    if not self.report.reporters_enabled:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Report' object has no attribute 'reporters_enabled'
```